### PR TITLE
fix: cleanup rpmlint workflow

### DIFF
--- a/.github/workflows/rpmlint.yml
+++ b/.github/workflows/rpmlint.yml
@@ -16,17 +16,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  push-ghcr:
-    name: rpmlint
+  rpmlint:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
-      id-token: write
-    strategy:
-      fail-fast: false
     steps:
-      - name: Perform checkout
+      - name: Checkout
         uses: actions/checkout@v4
 
       - name: Find spec files

--- a/.github/workflows/rpmlint.yml
+++ b/.github/workflows/rpmlint.yml
@@ -3,15 +3,15 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
+    paths:
+      - '**.spec'
+      - '.github/workflows/rpmlint.yml'
   push:
     branches:
       - main
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
+    paths:
+      - '**.spec'
+      - '.github/workflows/rpmlint.yml'
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/rpmlint.yml
+++ b/.github/workflows/rpmlint.yml
@@ -24,12 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Find spec files
-        run: |
-          SPECS=$(find ./ -type 'f' | grep "\.spec")
-          echo "SPECS=$SPECS" >> $GITHUB_ENV
-
       - name: Run rpmlint
         uses: EyeCantCU/rpmlint-action@v0.1.0
         with:
-          rpmfiles: ${{ env.SPECS }}
+          rpmfiles: .


### PR DESCRIPTION
The current action does not support defining multiple spec files (PR in progress), but rpmlint does allow you to point it at a directory and it will check all subdirectories recursively, which I have done here.  

Also made this workflow run only when there are changes to the .spec files, since these are the only thing checked by rpmlint.

Finally removed some unused permissions on the workflow, such as permissions to packages, since these were unused.