### PR TITLE
feat: add rtl8814au wifi driver

### DIFF
--- a/staging/rtl8814au/rtl8814au-kmod.spec
+++ b/staging/rtl8814au/rtl8814au-kmod.spec
@@ -44,7 +44,7 @@ for kernel_version  in %{?kernel_versions} ; do
   pushd _kmod_build_${kernel_version%%___*}/
   cd %{srcname}-%{srccommit}
   make clean
-  make
+  make KVER=${kernel_version%%___*}
   # Rename the module to have rtl prefix for Realtek
   mv %{srcname}.ko %{modname}.ko
   popd

--- a/staging/rtl8814au/rtl8814au-kmod.spec
+++ b/staging/rtl8814au/rtl8814au-kmod.spec
@@ -1,0 +1,64 @@
+%global srccommit 866a9100c7b3f6508b81b31a22cae19dcacdacb9
+%global modname rtl8814au
+%global srcname 8814au
+
+%if 0%{?fedora}
+%global buildforkernels akmod
+%global debug_package %{nil}
+%endif
+
+# name should have a -kmod suffix
+Name:           %{modname}-kmod
+# Version comes from include/rtw_version.h
+Version:        5.8.5.1.git
+Release:        1%{?dist}
+Summary:        Realtek RTL8814AU Driver
+Group:          System Environment/Kernel
+License:        GPLv2
+URL:            https://github.com/morrownr/8814au
+Source0:        %{url}/archive/%{srccommit}.zip
+
+BuildRequires: kmodtool
+
+%{expand:%(kmodtool --target %{_target_cpu} --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+
+%description
+Realtek RTL8814AU Driver
+
+%prep
+# error out if there was something wrong with kmodtool
+%{?kmodtool_check}
+
+# print kmodtool output for debugging purposes:
+kmodtool --target %{_target_cpu} --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+
+%autosetup -c %{modname}
+
+for kernel_version  in %{?kernel_versions} ; do
+  mkdir -p _kmod_build_${kernel_version%%___*}
+  cp -a %{srcname}-%{srccommit} _kmod_build_${kernel_version%%___*}/
+done
+
+%build
+for kernel_version  in %{?kernel_versions} ; do
+  pushd _kmod_build_${kernel_version%%___*}/
+  cd %{srcname}-%{srccommit}
+  make clean
+  make
+  # Rename the module to have rtl prefix for Realtek
+  mv %{srcname}.ko %{modname}.ko
+  popd
+done
+
+%install
+for kernel_version in %{?kernel_versions}; do
+ mkdir -p %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ install -D -m 755 _kmod_build_${kernel_version%%___*}/%{srcname}-%{srccommit}/%{modname}.ko %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ chmod a+x %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/%{modname}.ko
+done
+%{?akmod_install}
+
+%clean
+rm -rf "%{buildroot}"
+
+%changelog

--- a/staging/rtl8814au/rtl8814au.spec
+++ b/staging/rtl8814au/rtl8814au.spec
@@ -1,0 +1,29 @@
+%global modname rtl8814au
+
+%if 0%{?fedora}
+%global debug_package %{nil}
+%endif
+
+Name:     %{modname}
+Version:  5.8.5.1.git
+Release:  1%{?dist}
+Summary:  Realtek RTL8814AU Driver
+License:  GPLv2
+URL:      https://github.com/morrownr/8814au
+Source0:  https://raw.githubusercontent.com/morrownr/8814au/main/LICENSE
+
+Provides: %{name}-kmod-common = %{version}
+Requires: %{name}-kmod >= %{version}
+
+BuildRequires: systemd-rpm-macros
+
+%description
+Realtek RTL8814AU Driver
+
+%build
+install -D -m 0644 %{SOURCE0} %{buildroot}%{_datarootdir}/licenses/%{modname}/LICENSE
+
+%files
+%license LICENSE
+
+%changelog


### PR DESCRIPTION
This PR adds two spec files to build akmods packages for the rtl8814au driver. I've been testing it with a `0846:9054 NetGear, Inc. Nighthawk A7000 802.11ac Wireless Adapter AC1900 [Realtek 8814AU]` and the driver appears to be working and the kernel modules aliases seem to update correctly when the akmods package builds and installs inside a distrobox container. I'm not totally sure how to get it into rpm-ostree for testing against the host though.

I've got it building in my [copr here](https://copr.fedorainfracloud.org/coprs/zerochill/akmods/).

I am new to using akmods for building, so let me know if anything looks wrong. I tried to follow some examples from the existing ublue-os akmods copr builds.