### PR TITLE
feat: add rtl88xxau driver

### DIFF
--- a/akmods/rtl8814au/rtl8814au-kmod.spec
+++ b/akmods/rtl8814au/rtl8814au-kmod.spec
@@ -58,7 +58,4 @@ for kernel_version in %{?kernel_versions}; do
 done
 %{?akmod_install}
 
-%clean
-rm -rf "%{buildroot}"
-
 %changelog

--- a/akmods/rtl8814au/rtl8814au-kmod.spec
+++ b/akmods/rtl8814au/rtl8814au-kmod.spec
@@ -11,7 +11,7 @@
 Name:           %{modname}-kmod
 # Version comes from include/rtw_version.h
 Version:        5.8.5.1.git
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Realtek RTL8814AU Driver
 Group:          System Environment/Kernel
 License:        GPLv2

--- a/akmods/rtl8814au/rtl8814au.spec
+++ b/akmods/rtl8814au/rtl8814au.spec
@@ -10,7 +10,7 @@ Release:  1%{?dist}
 Summary:  Realtek RTL8814AU Driver
 License:  GPLv2
 URL:      https://github.com/morrownr/8814au
-Source0:  https://raw.githubusercontent.com/morrownr/8814au/main/LICENSE
+Source0:  https://raw.githubusercontent.com/morrownr/8814au/main/LICENSE?name=LICENSE.%{modname}
 
 Provides: %{name}-kmod-common = %{version}
 Requires: %{name}-kmod >= %{version}
@@ -21,6 +21,9 @@ BuildRequires: systemd-rpm-macros
 Realtek RTL8814AU Driver
 
 %build
+cp %{SOURCE0} LICENSE
+
+%install
 install -D -m 0644 %{SOURCE0} %{buildroot}%{_datarootdir}/licenses/%{modname}/LICENSE
 
 %files

--- a/akmods/rtl8814au/rtl8814au.spec
+++ b/akmods/rtl8814au/rtl8814au.spec
@@ -6,7 +6,7 @@
 
 Name:     %{modname}
 Version:  5.8.5.1.git
-Release:  1%{?dist}
+Release:  2%{?dist}
 Summary:  Realtek RTL8814AU Driver
 License:  GPLv2
 URL:      https://github.com/morrownr/8814au

--- a/akmods/rtl88xxau/rtl88xxau-kmod.spec
+++ b/akmods/rtl88xxau/rtl88xxau-kmod.spec
@@ -1,0 +1,55 @@
+%global modname 88XXau
+%global srcversion 5.6.4.2
+%global srcname rtl8812au
+%global pkgname rtl88xxau
+
+%if 0%{?fedora}
+%global buildforkernels akmod
+%global debug_package %{nil}
+%endif
+
+# name should have a -kmod suffix
+Name:          %{pkgname}-kmod
+Version:       %{srcversion}.git
+Release:       1%{?dist}
+Summary:       Realtek RTL8812AU/21AU and RTL8814AU driver
+License:       GPLv2
+URL:           https://github.com/aircrack-ng/rtl8812au
+Source0:       %{url}/archive/refs/heads/v%{srcversion}.zip
+
+BuildRequires: kmodtool
+
+%{expand:%(kmodtool --target %{_target_cpu} --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+
+%description
+Realtek RTL8812AU/21AU and RTL8814AU driver with monitor mode and frame injection
+
+%prep
+# error out if there was something wrong with kmodtool
+%{?kmodtool_check}
+
+# print kmodtool output for debugging purposes:
+kmodtool --target %{_target_cpu} --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+
+%autosetup -c %{pkgname}
+for kernel_version  in %{?kernel_versions} ; do
+  cp -a %{srcname}-%{srcversion} _kmod_build_${kernel_version%%___*}/
+done
+
+%build
+for kernel_version  in %{?kernel_versions} ; do
+  pushd _kmod_build_${kernel_version%%___*}/
+  make clean
+  make KVER=${kernel_version%%___*}
+  popd
+done
+
+%install
+for kernel_version in %{?kernel_versions}; do
+ mkdir -p %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ install -D -m 755 _kmod_build_${kernel_version%%___*}/%{modname}.ko %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+ chmod a+x %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/%{modname}.ko
+done
+%{?akmod_install}
+
+%changelog

--- a/akmods/rtl88xxau/rtl88xxau.spec
+++ b/akmods/rtl88xxau/rtl88xxau.spec
@@ -1,0 +1,35 @@
+%global modname 88XXau
+%global srcversion 5.6.4.2
+%global srcname rtl8812au
+%global pkgname rtl88xxau
+
+%if 0%{?fedora}
+%global debug_package %{nil}
+%endif
+
+Name:     %{pkgname}
+Version:  %{srcversion}.git
+Release:  1%{?dist}
+Summary:  Realtek RTL8812AU/21AU and RTL8814AU driver
+License:  GPLv2
+URL:      https://github.com/aircrack-ng/rtl8812au
+Source0:  https://raw.githubusercontent.com/aircrack-ng/rtl8812au/v%{srcversion}/LICENSE?name=LICENSE.%{pkgname}
+
+Provides: %{name}-kmod-common = %{version}
+Requires: %{name}-kmod >= %{version}
+
+BuildRequires: systemd-rpm-macros
+
+%description
+Realtek RTL8812AU/21AU and RTL8814AU driver with monitor mode and frame injection
+
+%build
+cp %{SOURCE0} LICENSE
+
+%install
+install -D -m 0644 %{SOURCE0} %{buildroot}%{_datarootdir}/licenses/%{pkgname}/LICENSE
+
+%files
+%license LICENSE
+
+%changelog


### PR DESCRIPTION
This adds the 88xxau drivers from aircrack-ng which works for Realtek RTL8812AU/21AU and RTL8814AU. I was able to verify that it is working and co-existing with the rtl8814au driver that is already merged.

I found a packaging error with the license file in the rtl8814au build, so I updated that so it downloads to a unique filename and fixed up some rpmlint errors.

Edit: Also this is up in [my copr](https://copr.fedorainfracloud.org/coprs/zerochill/akmods/packages/) for testing