### PR TITLE
feat: add xone spec files from last known working build

### DIFF
--- a/akmods/xone/xone-kmod-common.spec
+++ b/akmods/xone/xone-kmod-common.spec
@@ -1,0 +1,56 @@
+%global real_name xone
+
+Name:           %{real_name}-kmod-common
+Version:        0.3
+Release:        3%{?dist}
+Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories common files
+License:        GPLv2
+URL:            https://github.com/medusalix/%{real_name}
+BuildArch:      noarch
+
+Source0:        %{url}/archive/v%{version}.tar.gz#/%{real_name}-%{version}.tar.gz
+# Windows driver and firmware file:
+Source1:        http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab
+
+BuildRequires:  cabextract
+# UDev rule location (_udevrulesdir) and systemd macros:
+BuildRequires:  systemd-rpm-macros
+
+Requires:       wireless-regdb
+Requires:       %{real_name}-kmod = %{?epoch:%{epoch}:}%{version}
+Provides:       %{real_name}-kmod-common = %{?epoch:%{epoch}:}%{version}
+
+%description
+Linux kernel driver for Xbox One and Xbox Series X|S accessories common files.
+ 
+%prep
+%autosetup -p1 -n %{real_name}-%{version}
+
+# Firmware:
+cabextract -F FW_ACC_00U.bin %{SOURCE1}
+
+%install
+mkdir -p %{buildroot}%{_udevrulesdir}
+mkdir -p %{buildroot}%{_prefix}/lib/modprobe.d/
+
+# Blacklist:
+install -p -m 0644 install/modprobe.conf %{buildroot}%{_prefix}/lib/modprobe.d/xone.conf
+
+# Firmware:
+install -p -m 0644 -D FW_ACC_00U.bin %{buildroot}%{_prefix}/lib/firmware/xow_dongle.bin
+
+%files
+%license LICENSE
+%doc README.md
+%{_prefix}/lib/modprobe.d/%{real_name}.conf
+%{_prefix}/lib/firmware/xow_dongle.bin
+
+%changelog
+* Wed Jan 17 2024 Simone Caronni <negativo17@gmail.com> - 0.3-3
+- Clean up SPEC file.
+
+* Sat Dec 17 2022 Simone Caronni <negativo17@gmail.com> - 0.3-2
+- Kernel module checks for wireless frequency regulatory compliance.
+
+* Tue Aug 9 2022 Simone Caronni <negativo17@gmail.com> - 0.3-1
+- First build.

--- a/akmods/xone/xone-kmod.spec
+++ b/akmods/xone/xone-kmod.spec
@@ -1,0 +1,76 @@
+%global commit0 af5e344fb0203738c5892e295aa4f7138889393d
+%global date 20240116
+%global shortcommit0 %(c=%{commit0}; echo ${c:0:7})
+#global tag %{version}
+
+# Build only the akmod package and no kernel module packages:
+%define buildforkernels akmod
+
+%global debug_package %{nil}
+
+Name:           xone-kmod
+Version:        0.3
+Release:        4%{!?tag:.%{date}git%{shortcommit0}}%{?dist}
+Summary:        Linux kernel driver for Xbox One and Xbox Series X|S accessories
+License:        GPLv2
+URL:            https://github.com/medusalix/xone
+
+%if 0%{?tag:1}
+Source0:        %{url}/archive/v%{version}.tar.gz#/xone-%{version}.tar.gz
+%else
+Source0:        %{url}/archive/%{commit0}.tar.gz#/xone-%{shortcommit0}.tar.gz
+%endif
+
+# Get the needed BuildRequires (in parts depending on what we build for):
+BuildRequires:  kmodtool
+
+# kmodtool does its magic here
+%{expand:%(kmodtool --target %{_target_cpu} --repo negativo17.org --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+
+%description
+Linux kernel driver for Xbox One and Xbox Series X|S accessories.
+
+%prep
+# Error out if there was something wrong with kmodtool:
+%{?kmodtool_check}
+# Print kmodtool output for debugging purposes:
+kmodtool  --target %{_target_cpu}  --repo negativo17.org --kmodname %{name} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+
+%if 0%{?tag:1}
+%autosetup -p1 -n xone-%{version}
+%else
+%autosetup -p1 -n xone-%{commit0}
+%endif
+
+for kernel_version in %{?kernel_versions}; do
+    mkdir _kmod_build_${kernel_version%%___*}
+    cp -fr bus driver transport Kbuild _kmod_build_${kernel_version%%___*}
+done
+
+%build
+for kernel_version in %{?kernel_versions}; do
+    pushd _kmod_build_${kernel_version%%___*}/
+        %make_build -C "${kernel_version##*___}" M=$(pwd) VERSION="v%{version}" modules
+    popd
+done
+
+%install
+for kernel_version in %{?kernel_versions}; do
+    mkdir -p %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+    install -p -m 0755 _kmod_build_${kernel_version%%___*}/*.ko \
+        %{buildroot}/%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+done
+%{?akmod_install}
+
+%changelog
+* Wed Jan 17 2024 Simone Caronni <negativo17@gmail.com> - 0.3-4.20240116gitaf5e344
+- Update to latest snapshot.
+
+* Wed Nov 15 2023 Simone Caronni <negativo17@gmail.com> - 0.3-3.20230517gitbbf0dcc
+- Drop custom signing and compressing in favour of kmodtool.
+
+* Sun Jun 04 2023 Simone Caronni <negativo17@gmail.com> - 0.3-2.20230517gitbbf0dcc
+- Update to latest commits.
+
+* Tue Aug 9 2022 Simone Caronni <negativo17@gmail.com> - 0.3-1
+- First build.


### PR DESCRIPTION
Negativo17 updated their spec files on 2024-01-17 to use the latest snapshot from xone driver commit af5e344fb0203738c5892e295aa4f7138889393d

This was the "Allow repeated GIP announcements" commit.

A few newer commits adding GIP authentication are failing builds. So this is a copy of the spec files at known good build state and we can update when newer features build properly.