### PR TITLE
feat: Add initial support for building Wolfi packages

### DIFF
--- a/.github/workflows/wolfi.yml
+++ b/.github/workflows/wolfi.yml
@@ -27,7 +27,8 @@ jobs:
 
       - name: Generate package list
         run: |
-          APK_LIST=$(ls wolfi | tr '\n' ',')
+          cd wolfi
+          APK_LIST=$(find *.yaml -type 'f' | tr '\n' ',')
           echo "APK_LIST=$APK_LIST" >> $GITHUB_ENV
 
       # Build APKs with melange

--- a/.github/workflows/wolfi.yml
+++ b/.github/workflows/wolfi.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Generate package list
         run: |
           cd wolfi
+          # Copy package resources to workdir
+          RESOURCES=$(ls -d */)
+          for resource in $RESOURCES; do
+            cp -r $resource/* .
+          done
+          # Create package list
           APK_LIST=$(find *.yaml -type 'f' | tr '\n' ',')
           echo "APK_LIST=$APK_LIST" >> $GITHUB_ENV
 

--- a/.github/workflows/wolfi.yml
+++ b/.github/workflows/wolfi.yml
@@ -1,7 +1,7 @@
 name: Build and Upload Wolfi Packages
 on:
   schedule:
-    - cron: '0 5,17 * * *'  # 5am and 5pm every day
+    - cron: '50 5,17 * * *'  # 5:50 AM and 5:50 PM UTC every day
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/wolfi.yml
+++ b/.github/workflows/wolfi.yml
@@ -1,0 +1,51 @@
+name: Build and Upload Wolfi Packages
+on:
+  schedule:
+    - cron: '0 5,17 * * *'  # 5am and 5pm every day
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  upload-wolfi-packages:
+    name: Build and upload Wolfi packages
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+    steps:
+      # Checkout push-to-registry action GitHub repository
+      - name: Checkout Push to Registry action
+        uses: actions/checkout@v4
+
+      - name: Generate package list
+        run: |
+          APK_LIST=$(ls wolfi | tr '\n' ',')
+          echo "APK_LIST=$APK_LIST" >> $GITHUB_ENV
+
+      # Build APKs with melange
+      - name: Build APKs
+        id: melange
+        uses: chainguard-dev/actions/melange-build@main
+        with:
+          archs: aarch64,x86_64
+          empty-workspace: false
+          multi-config: ${{ env.APK_LIST }}
+          sign-with-temporary-key: true
+          workdir: ./wolfi
+
+      # Upload packages
+      - name: 'Upload built packages archive to Github Artifacts'
+        uses: actions/upload-artifact@v4
+        with:
+          name: wolfi-packages
+          path: ./packages
+          retention-days: 1 # Low ttl since this is just an intermediary used once
+          if-no-files-found: error

--- a/wolfi/bluefin-base.yaml
+++ b/wolfi/bluefin-base.yaml
@@ -1,0 +1,52 @@
+package:
+  name: bluefin-base
+  version: 0.0.0
+  epoch: 0
+  description: "Bluefin metapackage"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - atuin
+      - brew
+      - gawk
+      - eza
+      - fd
+      - fish
+      - fzf
+      - rclone
+      - ripgrep
+      - sed
+      - starship
+      - ublue-base
+      - uutils
+      - zoxide
+      - zsh
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - curl
+
+pipeline:
+  - runs: |
+      # Symlink linuxbrew to homebrew
+      mkdir -p "${{targets.destdir}}"/home
+      ln -sf /home/linuxbrew "${{targets.destdir}}"/home/homebrew
+
+      # Install bash-prexec
+      mkdir -p "${{targets.destdir}}"/usr/share
+      curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o "${{targets.destdir}}"/usr/share/bash-prexec
+
+      # Copy system files
+      cp -r etc "${{targets.destdir}}"
+      cp -r usr "${{targets.destdir}}"
+      cp -r root "${{targets.destdir}}"
+
+update:
+  manual: true

--- a/wolfi/bluefin-base/etc/bashrc
+++ b/wolfi/bluefin-base/etc/bashrc
@@ -1,0 +1,66 @@
+# shellcheck shell=bash disable=SC1091
+# /etc/bashrc
+
+# System wide functions and aliases
+# Environment stuff goes in /etc/profile
+
+# It's NOT a good idea to change this file unless you know what you
+# are doing. It's much better to create a custom.sh shell script in
+# /etc/profile.d/ to make custom changes to your environment, as this
+# will prevent the need for merging in future updates.
+
+# Prevent doublesourcing
+if [ -z "$PROFILESOURCED" ] && [ "$PS1" ]; then
+  PROFILESOURCED="Y"
+  . /etc/profile
+fi
+
+if [ -z "$BASHRCSOURCED" ]; then
+  BASHRCSOURCED="Y"
+
+  # are we an interactive shell?
+  if [ "$PS1" ]; then
+    if [ -z "$PROMPT_COMMAND" ]; then
+      case $TERM in
+      xterm*)
+        PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"'
+        ;;
+      screen*)
+        PROMPT_COMMAND='printf "\033k%s@%s:%s\033\\" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"'
+        ;;
+      *)
+        [ -e /etc/sysconfig/bash-prompt-default ] && PROMPT_COMMAND=/etc/sysconfig/bash-prompt-default
+        ;;
+      esac
+    fi
+    # Turn on parallel history
+    shopt -s histappend
+    # Turn on checkwinsize
+    shopt -s checkwinsize
+    [ "$PS1" = "\\s-\\v\\\$ " ] && PS1="[\u@\h \W]\\$ "
+    # You might want to have e.g. tty in prompt (e.g. more virtual machines)
+    # and console windows
+    # If you want to do so, just add e.g.
+    # if [ "$PS1" ]; then
+    #   PS1="[\u@\h:\l \W]\\$ "
+    # fi
+    # to your custom modification shell script in /etc/profile.d/ directory
+  fi
+  STARSHIP_CONFIG=/etc/starship.toml
+  export STARSHIP_CONFIG
+  eval "$(starship init bash)"
+
+  # Enable fzf keybindings
+  [ -r /run/host/usr/share/fzf/shell/key-bindings.bash ] && \
+  . /run/host/usr/share/fzf/shell/key-bindings.bash
+
+  # Enable atuin and bash-prexec
+  source /usr/share/bash-prexec
+  eval "$(atuin init bash)"
+
+  # Enable zoxide
+  eval "$(zoxide init bash --cmd cd)"
+fi
+
+# vim:ts=4:sw=4
+

--- a/wolfi/bluefin-base/etc/profile.d/00-bluefin-cli-brew-firstrun.sh
+++ b/wolfi/bluefin-base/etc/profile.d/00-bluefin-cli-brew-firstrun.sh
@@ -1,0 +1,47 @@
+# shellcheck shell=sh disable=SC1091
+if test "$(id -u)" -gt "0"; then
+  blue=$(printf '\033[38;5;32m')
+  bold=$(printf '\033[1m')
+  normal=$(printf '\033[0m')
+  if test ! -f /etc/linuxbrew.firstrun; then
+    printf "\nBluefin-CLI First Run Setup\n\n"
+    printf "Setting up sudo for %s%s%s%s...\t\t\t " "$bold" "$blue" "$USER" "$normal"
+    echo "#$(id -u) ALL = (root) NOPASSWD:ALL" | su-exec root tee -a /etc/sudoers > /dev/null
+    printf "%s[ OK ]%s\n" "${blue}" "${normal}"
+  fi
+
+  if test ! -d /home/linuxbrew/.linuxbrew; then
+    name="$(hostname -s)"
+    linuxbrew_home="${XDG_DATA_HOME:-$HOME/.local/share}"/bluefin-cli/"${name}"
+    printf "Setting up Linuxbrew...\t\t\t\t "
+    if test ! -d "${linuxbrew_home}"; then
+      mkdir -p "${linuxbrew_home}"
+      if test -d "${XDG_DATA_HOME:-$HOME/.local/share}"/bluefin-cli/.linuxbrew; then
+        mv "${XDG_DATA_HOME:-$HOME/.local/share}"/bluefin-cli/.linuxbrew "${linuxbrew_home}"/.linuxbrew
+      fi
+    fi
+    if test ! -d /home/linuxbrew; then
+      su-exec root mkdir -p /home/linuxbrew
+    fi
+    su-exec root mount --bind "${linuxbrew_home}" /home/linuxbrew
+    su-exec root cp -R /home/homebrew/.linuxbrew /home/linuxbrew/
+    su-exec root chown -R "$(id -u)" /home/linuxbrew
+    unset linuxbrew_home
+    printf "%s[ OK ]%s\n" "${blue}" "${normal}"
+  fi
+
+  if test ! -d /usr/local/share/bash-completion/completions; then
+    printf "Setting up Tab-Completions...\t\t\t "
+    su-exec root mkdir -p /usr/local/share/bash-completion
+    su-exec root mount --bind /run/host/usr/share/bash-completion /usr/local/share/bash-completion
+    if test -x /run/host/usr/bin/ujust; then
+      su-exec root ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/ujust
+    fi
+    printf "%s[ OK ]%s\n" "${blue}" "${normal}"
+  fi
+
+  if test ! -f /etc/linuxbrew.firstrun; then
+    su-exec root touch /etc/linuxbrew.firstrun
+    printf "\nBluefin-CLI first run complete!\n\n"
+  fi
+fi

--- a/wolfi/bluefin-base/etc/profile.d/bash_completion.sh
+++ b/wolfi/bluefin-base/etc/profile.d/bash_completion.sh
@@ -1,0 +1,42 @@
+# shellcheck shell=sh disable=SC1090,SC1091,SC2039,SC2166,SC2268
+# Check for interactive bash and that we haven't already been sourced.
+if [ "x${BASH_VERSION-}" != x -a "x${PS1-}" != x -a "x${BASH_COMPLETION_VERSINFO-}" = x ]; then
+
+    # Check for recent enough version of bash.
+    if [ "${BASH_VERSINFO[0]}" -gt 4 ] ||
+        [ "${BASH_VERSINFO[0]}" -eq 4 -a "${BASH_VERSINFO[1]}" -ge 2 ]; then
+        [ -r "${XDG_CONFIG_HOME:-$HOME/.config}/bash_completion" ] &&
+            . "${XDG_CONFIG_HOME:-$HOME/.config}/bash_completion"
+        if shopt -q progcomp && [ -d /usr/share/bash-completion/completions ]; then
+            for rc in /usr/share/bash-completion/completions/*; do
+                if test -r "$rc"; then
+                    . "$rc"
+                fi
+            done
+            unset rc
+        fi
+        if shopt -q progcomp && [ -r /usr/local/share/bash-completion/bash_completion ]; then
+            # Source completion code.
+            . /usr/local/share/bash-completion/bash_completion
+        fi
+        if ! test -L /home/linuxbrew/.linuxbrew/etc/bash_completion.d/brew && test "$(id -u)" -gt 0; then
+            /home/linuxbrew/.linuxbrew/bin/brew completions link > /dev/null
+        fi
+        if test -d /home/linuxbrew/.linuxbrew/etc/bash_completion.d; then
+            for rc in /home/linuxbrew/.linuxbrew/etc/bash_completion.d/*; do
+              if test -r "$rc"; then
+                . "$rc"
+              fi
+            done
+            unset rc
+        fi
+        if test -d /run/host/etc/bash_completion.d; then
+            for rc in /run/host/etc/bash_completion.d/*; do
+                if test -r "$rc"; then
+                    . "$rc"
+                fi
+            done
+            unset rc
+        fi
+    fi
+fi

--- a/wolfi/bluefin-base/etc/profile.d/command-not-found-host-exec.sh
+++ b/wolfi/bluefin-base/etc/profile.d/command-not-found-host-exec.sh
@@ -1,0 +1,14 @@
+# shellcheck shell=sh
+command_not_found_handle() {
+# don't run if not in a container
+  if [ ! -e /run/.containerenv ] && [ ! -e /.dockerenv ]; then
+    exit 127
+  fi
+  
+  distrobox-host-exec "${@}"
+}
+if [ -n "${ZSH_VERSION-}" ]; then
+  command_not_found_handler() {
+    command_not_found_handle "$@"
+ }
+fi

--- a/wolfi/bluefin-base/etc/profile.d/homebrew-env.sh
+++ b/wolfi/bluefin-base/etc/profile.d/homebrew-env.sh
@@ -1,0 +1,10 @@
+# shellcheck shell=sh
+
+PATH="$PATH:/home/linuxbrew/.linuxbrew/sbin"
+export PATH
+HOMEBREW_REPOSITORY="/home/linuxbrew/.linuxbrew"
+export HOMEBREW_REPOSITORY
+HOMEBREW_PREFIX="/home/linuxbrew/.linuxbrew"
+export HOMEBREW_PREFIX
+HOMEBREW_CELLAR="/home/linuxbrew/.linuxbrew/Cellar"
+export HOMEBREW_CELLAR

--- a/wolfi/bluefin-base/etc/profile.d/modern-unix.sh
+++ b/wolfi/bluefin-base/etc/profile.d/modern-unix.sh
@@ -1,0 +1,20 @@
+# shellcheck shell=sh
+# Eza for ls
+alias ll='eza -l --icons=auto --group-directories-first' 2>/dev/null
+alias l.='eza -d .*' 2>/dev/null
+alias ls='eza' 2>/dev/null
+alias l1='eza -1'
+
+# Ripgrep for grep
+alias grep='rg' 2>/dev/null
+alias egrep='rg' 2>/dev/null
+alias fgrep='rg -F' 2>/dev/null
+alias xzgrep='rg -z' 2>/dev/null
+alias xzegrep='rg -z' 2>/dev/null
+alias xzfgrep='rg -z -F' 2>/dev/null
+
+# Zoxide is handling cd
+alias cd='cd' 2>/dev/null
+
+# Fd for find
+alias find='fd' 2>/dev/null

--- a/wolfi/bluefin-base/etc/profile.d/zz-profile_sourced.sh
+++ b/wolfi/bluefin-base/etc/profile.d/zz-profile_sourced.sh
@@ -1,0 +1,4 @@
+# shellcheck shell=sh
+if [ -z "$PROFILESOURCED" ] && [ "$PS1" ]; then
+  PROFILESOURCED="Y"
+fi

--- a/wolfi/bluefin-base/etc/starship.toml
+++ b/wolfi/bluefin-base/etc/starship.toml
@@ -1,0 +1,49 @@
+[character]
+success_symbol = '[\$](bold blue dimmed)'
+error_symbol = '[\$](bold red)'
+
+[container]
+symbol='📦'
+format='[$symbol](bold blue dimmed) '
+
+[directory]
+style = 'bold cyan dimmed'
+
+[hostname]
+ssh_only = false
+style = 'blue bold dimmed'
+format = '[$ssh_symbol$hostname]($style) '
+
+[username]
+style_user = 'blue bold dimmed'
+style_root = 'red bold'
+format = '[$user]($style)@'
+show_always = true
+
+[palettes.catppuccin_mocha]                                                                                                                                                                                     
+rosewater = "#f5e0dc"                                                                                                                                                                                           
+flamingo = "#f2cdcd"                                                                                                                                                                                            
+pink = "#f5c2e7"                                                                                                                                                                                                
+mauve = "#cba6f7"                                                                                                                                                                                               
+red = "#f38ba8"                                                                                                                                                                                                 
+maroon = "#eba0ac"                                                                                                                                                                                              
+peach = "#fab387"                                                                                                                                                                                               
+yellow = "#f9e2af"                                                                                                                                                                                              
+green = "#a6e3a1"                                                                                                                                                                                               
+teal = "#94e2d5"                                                                                                                                                                                                
+sky = "#89dceb"                                                                                                                                                                                                 
+sapphire = "#74c7ec"                                                                                                                                                                                            
+blue = "#89b4fa"                                                                                                                                                                                                
+lavender = "#b4befe"                                                                                                                                                                                            
+text = "#cdd6f4"                                                                                                                                                                                                
+subtext1 = "#bac2de"                                                                                                                                                                                            
+subtext0 = "#a6adc8"                                                                                                                                                                                            
+overlay2 = "#9399b2"                                                                                                                                                                                            
+overlay1 = "#7f849c"                                                                                                                                                                                            
+overlay0 = "#6c7086"                                                                                                                                                                                            
+surface2 = "#585b70"                                                                                                                                                                                            
+surface1 = "#45475a"                                                                                                                                                                                            
+surface0 = "#313244"                                                                                                                                                                                            
+base = "#1e1e2e"                                                                                                                                                                                                
+mantle = "#181825"                                                                                                                                                                                              
+crust = "#11111b" 

--- a/wolfi/bluefin-base/root/.bash_profile
+++ b/wolfi/bluefin-base/root/.bash_profile
@@ -1,0 +1,3 @@
+if [ -f ~/.bashrc ]; then
+    . ~/.bashrc
+fi

--- a/wolfi/bluefin-base/root/.bashrc
+++ b/wolfi/bluefin-base/root/.bashrc
@@ -1,0 +1,3 @@
+if [ -f /etc/bashrc ]; then
+    . /etc/bashrc
+fi

--- a/wolfi/bluefin-base/usr/share/fish/vendor_conf.d/00-bluefin-cli-brew-firstrun.fish
+++ b/wolfi/bluefin-base/usr/share/fish/vendor_conf.d/00-bluefin-cli-brew-firstrun.fish
@@ -1,0 +1,45 @@
+if test "$(id -u)" -gt "0"
+  set blue (set_color blue)
+  set bold (set_color -o blue)
+  set normal (set_color normal)
+  if test ! -f /etc/linuxbrew.firstrun
+    printf "\nBluefin-CLI First Run Setup\n\n"
+    printf "Setting up sudo for %s%s%s...\t\t\t " "$bold" "$USER" "$normal"
+    echo "#$UID ALL = (root) NOPASSWD:ALL" | su-exec root tee -a /etc/sudoers > /dev/null
+    printf "%s[ OK ]%s\n" "$blue" "$normal"
+  end
+
+  if test ! -d /home/linuxbrew/.linuxbrew
+    set name $(hostname -s)
+    set xdg_data_home "$XDG_DATA_HOME"
+    test -z "$xdg_data_home"; and set xdg_data_home "$HOME/.local/share/"
+    set linuxbrew_home "$xdg_data_home/bluefin-cli/$name"
+    printf "Setting up Linuxbrew...\t\t\t\t "
+    if test ! -d "$linuxbrew_home"
+      mkdir -p "$linuxbrew_home"
+    end
+    if test ! -d /home/linuxbrew
+      su-exec root mkdir -p /home/linuxbrew
+    end
+    su-exec root mount --bind "$linuxbrew_home" /home/linuxbrew
+    su-exec root cp -R /home/homebrew/.linuxbrew /home/linuxbrew/
+    su-exec root chown -R "$UID" /home/linuxbrew
+    set -e linuxbrew_home
+    printf "%s[ OK ]%s\n" "$blue" "$normal"
+  end
+
+  if test ! -d /usr/local/share/bash-completion/completions
+    printf "Setting up Tab-Completions...\t\t\t "
+    su-exec root mkdir -p /usr/local/share/bash-completion
+    su-exec root mount --bind /run/host/usr/share/bash-completion /usr/local/share/bash-completion
+    if test -x /run/host/usr/bin/ujust
+      su-exec root ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/ujust
+    end
+    printf "%s[ OK ]%s\n" "$blue" "$normal"
+  end
+
+  if test ! -f /etc/linuxbrew.firstrun
+    su-exec root touch /etc/linuxbrew.firstrun
+    printf "\nBluefin-CLI first run complete!\n\n"
+  end
+end

--- a/wolfi/bluefin-base/usr/share/fish/vendor_conf.d/bling.fish
+++ b/wolfi/bluefin-base/usr/share/fish/vendor_conf.d/bling.fish
@@ -1,0 +1,27 @@
+if status is-interactive
+    set -gx STARSHIP_CONFIG /etc/starship.toml
+    eval "$(starship init fish)"
+    eval "$(atuin init fish)"
+    eval "$(zoxide init fish --cmd cd)"
+    set -gx HOST (hostname -s)
+end
+
+# Eza for ls
+alias ll='eza -l --icons=auto --group-directories-first' 2>/dev/null
+alias l.='eza -d .*' 2>/dev/null
+alias ls='eza' 2>/dev/null
+alias l1='eza -1'
+
+# Ripgrep for grep
+alias grep='rg' 2>/dev/null
+alias egrep='rg' 2>/dev/null
+alias fgrep='rg -F' 2>/dev/null
+alias xzgrep='rg -z' 2>/dev/null
+alias xzegrep='rg -z' 2>/dev/null
+alias xzfgrep='rg -z -F' 2>/dev/null
+
+# Zoxide is handling cd
+alias cd='cd' 2>/dev/null
+
+# Fd for find
+alias find='fd' 2>/dev/null 

--- a/wolfi/bluefin-base/usr/share/fish/vendor_conf.d/brew.fish
+++ b/wolfi/bluefin-base/usr/share/fish/vendor_conf.d/brew.fish
@@ -1,0 +1,15 @@
+if test "$(id -u)" -gt "0"
+    set -gx PATH  $PATH /home/linuxbrew/.linuxbrew/bin
+    set -gx HOMEBREW_PREFIX /home/linuxbrew/.linuxbrew
+    set -gx HOMEBREW_CELLAR /home/linuxbrew/.linuxbrew/Cellar
+    set -gx HOMEBREW_REPOSITORY /home/linuxbrew/.linuxbrew
+    if ! test -L (brew --prefix)"/share/fish/completions"
+        brew completions link
+    end
+    if test -d (brew --prefix)"/share/fish/completions"
+        set -p fish_complete_path (brew --prefix)/share/fish/completions
+    end
+    if test -d (brew --prefix)"/share/fish/vendor_completions.d"
+        set -p fish_complete_path (brew --prefix)/share/fish/vendor_completions.d
+    end
+end

--- a/wolfi/bluefin-base/usr/share/fish/vendor_functions.d/fish_command_not_found.fish
+++ b/wolfi/bluefin-base/usr/share/fish/vendor_functions.d/fish_command_not_found.fish
@@ -1,0 +1,8 @@
+function fish_command_not_found
+    # "In a container" check
+    if test -e /run/.containerenv -o -e /.dockerenv
+        distrobox-host-exec $argv
+    else
+        __fish_default_command_not_found_handler $argv
+    end
+end

--- a/wolfi/bluefin-base/usr/share/fish/vendor_functions.d/fish_title.fish
+++ b/wolfi/bluefin-base/usr/share/fish/vendor_functions.d/fish_title.fish
@@ -1,0 +1,4 @@
+function fish_title
+    set -q argv[1]; or set argv fish
+    echo "$USER@$HOST" (fish_prompt_pwd_dir_length=1 prompt_pwd): $argv
+end

--- a/wolfi/ublue-base.yaml
+++ b/wolfi/ublue-base.yaml
@@ -1,0 +1,96 @@
+package:
+  name: ublue-base
+  version: 0.0.0
+  epoch: 0
+  description: "Universal Blue metapackage"
+  copyright:
+    - license: Apache-2.0
+  dependencies:
+    runtime:
+      - bash
+      - busybox
+      - bzip2
+      - coreutils
+      - curl
+      - diffutils
+      - findmnt
+      - findutils
+      - git
+      - gnupg
+      - gpg
+      - iproute2
+      - iputils
+      - keyutils
+      - libcap
+      - libsm
+      - libx11
+      - libxau
+      - libxcb
+      - libxdmcp
+      - libxext
+      - libice
+      - libxmu
+      - libxt
+      - linux-pam
+      - man-db
+      - mount
+      - ncurses
+      - ncurses-terminfo
+      - net-tools
+      - openssh-client
+      - pigz
+      - posix-libc-utils
+      - procps
+      - rsync
+      - shadow
+      - su-exec
+      - tcpdump
+      - tree
+      - tzdata
+      - umount
+      - unzip
+      - util-linux
+      - util-linux-misc
+      - vulkan-loader
+      - wget
+      - xauth
+      - xz
+      - zip
+
+environment:
+  contents:
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+    repositories:
+      - https://packages.wolfi.dev/os
+    packages:
+      - busybox
+      - git
+      - wget
+
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.contextdir}}"/usr/bin
+      mkdir -p "${{targets.contextdir}}"/usr/local/bin
+
+      # Setup fake sudo and pinentry
+      install -Dm755 sudo "${{targets.contextdir}}"/usr/bin/sudo
+      install -Dm755 pinentry "${{targets.contextdir}}"/usr/bin/pinentry
+
+      # Get Distrobox-host-exec and host-spawn
+      git clone https://github.com/89luca89/distrobox.git --single-branch distrobox
+      install -Dm755 distrobox/distrobox-host-exec "${{targets.contextdir}}"/usr/bin/distrobox-host-exec
+      install -Dm755 distrobox/distrobox-export "${{targets.contextdir}}"/usr/bin/distrobox-export
+      install -Dm755 distrobox/distrobox-init "${{targets.contextdir}}"/usr/bin/entrypoint
+      wget https://github.com/1player/host-spawn/releases/download/$(cat distrobox/distrobox-host-exec | grep host_spawn_version= | cut -d "\"" -f 2)/host-spawn-$(uname -m) -O "${{ targets.contextdir }}"/usr/bin/host-spawn
+      chmod +x "${{ targets.contextdir }}"/usr/bin/host-spawn
+
+      # Make some symlinks
+      ln -sf /bin/sh "${{targets.contextdir}}"/usr/bin/sh
+      ln -sf /usr/bin/distrobox-host-exec "${{targets.contextdir}}"/usr/local/bin/docker
+      ln -sf /usr/bin/distrobox-host-exec "${{targets.contextdir}}"/usr/local/bin/flatpak
+      ln -sf /usr/bin/distrobox-host-exec "${{targets.contextdir}}"/usr/local/bin/podman
+      ln -sf /usr/bin/distrobox-host-exec "${{targets.contextdir}}"/usr/local/bin/rpm-ostree
+
+update:
+  manual: true

--- a/wolfi/ublue-base/pinentry
+++ b/wolfi/ublue-base/pinentry
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/wolfi/ublue-base/sudo
+++ b/wolfi/ublue-base/sudo
@@ -1,0 +1,2 @@
+#!/bin/sh
+/sbin/su-exec root "$@"


### PR DESCRIPTION
This PR adds rudimentary support for building Wolfi packages as well as metapackages for both Wolfi and Bluefin CLI images

This will need some refactoring in the future (namely automated package updates, isolating package resources, moving over to wolfictl, etc), but the core implementation works

Packages are uploaded as build artifacts to GitHub from where toolboxes will be able to retrieve the artifacts, resign the packages, and install them on the image