### PR TITLE
chore: Disable rpm-ostree backend in Gnome Software

### DIFF
--- a/staging/gnome-software/gnome-software.spec
+++ b/staging/gnome-software/gnome-software.spec
@@ -13,7 +13,7 @@
 # Disable parental control for RHEL builds
 %bcond malcontent %[!0%{?rhel}]
 # Disable rpm-ostree support for RHEL builds
-%bcond rpmostree %[!0%{?rhel}]
+%bcond rpmostree 0
 # Disable DKMS/akmods support for RHEL builds
 # Universal Blue: Disable entirely
 %bcond dkms 0

--- a/staging/gnome-software/gnome-software.spec
+++ b/staging/gnome-software/gnome-software.spec
@@ -13,6 +13,7 @@
 # Disable parental control for RHEL builds
 %bcond malcontent %[!0%{?rhel}]
 # Disable rpm-ostree support for RHEL builds
+# Universal Blue: Disable entirely
 %bcond rpmostree 0
 # Disable DKMS/akmods support for RHEL builds
 # Universal Blue: Disable entirely

--- a/staging/gnome-software/gnome-software.spec
+++ b/staging/gnome-software/gnome-software.spec
@@ -28,7 +28,7 @@
 
 Name:      gnome-software
 Version:   47.1
-Release:   100.ublue%{?dist}
+Release:   101.ublue%{?dist}
 Summary:   A software center for GNOME
 
 License:   GPL-2.0-or-later


### PR DESCRIPTION
Without strict need to declare removing `gnome-software-rpm-ostree` package in `main` image.
So makes modifications related to Gnome Software unified here.