### PR TITLE
Workaround for missing build ids

### DIFF
--- a/staging/devpod/devpod.spec
+++ b/staging/devpod/devpod.spec
@@ -1,3 +1,7 @@
+%if 0%{?fedora} == 41
+    _missing_build_ids_terminate_build 0
+%endif
+
 Name:           devpod
 # renovate: datasource=github-releases depName=loft-sh/devpod
 Version:        v0.5.21


### PR DESCRIPTION
Solves https://github.com/ublue-os/bluefin/issues/1875
See https://github.com/rpm-software-management/rpm/issues/367