### PR TITLE
feat: use topgrade fork with bootc support until they merge it

### DIFF
--- a/staging/topgrade/topgrade.spec
+++ b/staging/topgrade/topgrade.spec
@@ -1,13 +1,13 @@
 %global debug_package %{nil}
 
 Name:           topgrade
-Version:        15.0.0
-Release:        1%{?dist}
+Version:        16.0.1
+Release:        2%{?dist}
 Summary:        Upgrade all the things
 
 License:        GPL-3.0-or-later
 URL:            https://github.com/topgrade-rs/%{name}
-Source:         https://github.com/topgrade-rs/%{name}/archive/refs/tags/v%{version}.tar.gz
+Source:         https://github.com/topgrade-rs/%{name}/archive/14155d75c449a7d2df63b649cd359093550ddb07.tar.gz
 
 BuildRequires:  cargo
 BuildRequires:  rust
@@ -19,7 +19,7 @@ To remedy this, Topgrade detects which tools you use and
 runs the appropriate commands to update them.
 
 %prep
-%autosetup -n %{name}-%{version}
+%autosetup -n %{name}-14155d75c449a7d2df63b649cd359093550ddb07
 
 %build
 cargo build --release --locked


### PR DESCRIPTION
Changes the topgrade sources to that of https://github.com/topgrade-rs/topgrade/pull/986. Should be absolutely reverted whenever the PR gets merged into the next topgrade release
