### PR TITLE
feat: add new-lg4ff spec files

### DIFF
--- a/akmods/new-lg4ff/new-lg4ff-kmod.spec
+++ b/akmods/new-lg4ff/new-lg4ff-kmod.spec
@@ -1,0 +1,51 @@
+%global buildforkernels akmod
+%global debug_package %{nil}
+
+%global prjname new-lg4ff
+
+Name:           %{prjname}-kmod
+Summary:        Improved Linux module driver for Logitech driving wheels.
+Version:        0.4.0
+Release:        1%{?dist}
+License:        GPL-2.0-only
+
+URL:            https://github.com/berarma/new-lg4ff
+Source0:        %{url}/archive/%{version}/%{prjname}-%{version}.tar.gz
+
+BuildRequires:  kmodtool
+
+# kmodtool does its magic here
+%{expand:%(kmodtool --target %{_target_cpu} --kmodname %{prjname} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null) }
+
+%description
+Improved Linux module driver for Logitech driving wheels.
+
+This package contains the kmod module for %{prjname}.
+
+%prep
+# error out if there was something wrong with kmodtool
+%{?kmodtool_check}
+
+# print kmodtool output for debugging purposes:
+kmodtool  --target %{_target_cpu} --kmodname %{prjname} %{?buildforkernels:--%{buildforkernels}} %{?kernels:--for-kernels "%{?kernels}"} 2>/dev/null
+
+%autosetup -c %{name}-%{version}
+
+for kernel_version  in %{?kernel_versions} ; do
+    cp -a %{prjname}-%{version} _kmod_build_${kernel_version%%___*}
+done
+
+
+%build
+for kernel_version  in %{?kernel_versions} ; do
+  make V=1 %{?_smp_mflags} -C ${kernel_version##*___} M=${PWD}/_kmod_build_${kernel_version%%___*} VERSION=v%{version} modules
+done
+
+%install
+for kernel_version in %{?kernel_versions}; do
+    mkdir -p %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+    install -D -m 755 _kmod_build_${kernel_version%%___*}/*.ko %{buildroot}%{kmodinstdir_prefix}/${kernel_version%%___*}/%{kmodinstdir_postfix}/
+done
+%{?akmod_install}
+
+%changelog

--- a/akmods/new-lg4ff/new-lg4ff.spec
+++ b/akmods/new-lg4ff/new-lg4ff.spec
@@ -1,0 +1,36 @@
+%global buildforkernels akmod
+%global debug_package %{nil}
+
+Name:           new-lg4ff
+Version:        0.4.0
+Release:        1%{?dist}
+Summary:        Experimental Logitech force feedback module for Linux 
+License:        GPL-2.0-only
+
+URL:            https://github.com/berarma/new-lg4ff
+Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
+
+Provides:       %{name}-kmod-common = %{version}-%{release}
+Requires:       %{name}-kmod >= %{version}
+
+%description
+Improved Linux module driver for Logitech driving wheels.
+
+%prep
+%autosetup
+
+for kernel_version  in %{?kernel_versions} ; do
+  cp -a %{name}-%{version} _kmod_build_${kernel_version%%___*}
+done
+
+%build
+# Nothing to build
+
+%install
+# Nothing to install
+
+%files
+%doc README.md 
+%license LICENSE
+
+%changelog


### PR DESCRIPTION
adds spec files for [new-lg4ff](https://github.com/berarma/new-lg4ff) which enhances the `hid-logitech` kernel driver

Because the upstream driver will be loaded before this it will need to be blacklisted, however most people won't need this driver and while the lg4ff code in linux hasn't seen any real changes over the last years it might always receive changes that will not be present in the module so its best put behind a config or ujust script