### PR TITLE
feat(renovate): Add rule for kf6-kio

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,9 +13,10 @@
       "customType": "regex",
       "fileMatch": [".*\\.spec"],
       "matchStrings": [
-        "# renovate: datasource=yum repo=(?<registryUrl>[^\\s]+) pkg=(?<depName>[^\\s]+)\\s*%global majmin_ver_kf6 (?<currentValue>[^\\s]+)"
+        "# renovate: datasource=yum repo=(?<registryUrl>[^\\s]+) pkg=(?<depName>[^\\s]+)\\s*%global [^\\s]+ (?<currentValue>[^\\s]+)"
       ],
       "datasourceTemplate": "npm",
+      "extractVersionTemplate": "^(?<version>\\d\\.\\d)",
       "versioningTemplate": "loose",
       "registryUrlTemplate": "https://yum2npm.io/repos/{{replace '/' '/modules/' registryUrl}}/packages"
     }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,5 +9,16 @@
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
     }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [".*\\.spec"],
+      "matchStrings": [
+        "# renovate: datasource=yum repo=(?<registryUrl>[^\\s]+)\\s+(?<depName>[^\\s]+)-(?<currentValue>[^\\s-]+-[^\\s-]+)"
+      ],
+      "datasourceTemplate": "npm",
+      "versioningTemplate": "loose",
+      "registryUrlTemplate": "https://yum2npm.io/repos/{{replace '/' '/modules/' registryUrl}}/packages"
+    }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,17 +8,17 @@
         "#\\s?renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.*?))?\\s*Version:\\s*(?<currentValue>.*)\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
-    }
-  ],
-  "regexManagers": [
+    },
     {
+      "customType": "regex",
       "fileMatch": [".*\\.spec"],
       "matchStrings": [
-        "# renovate: datasource=yum repo=(?<registryUrl>[^\\s]+)\\s+(?<depName>[^\\s]+)-(?<currentValue>[^\\s-]+-[^\\s-]+)"
+        "# renovate: datasource=yum repo=(?<registryUrl>[^\\s]+) pkg=(?<depName>[^\\s]+)\\s*%global majmin_ver_kf6 (?<currentValue>[^\\s]+)"
       ],
       "datasourceTemplate": "npm",
       "versioningTemplate": "loose",
       "registryUrlTemplate": "https://yum2npm.io/repos/{{replace '/' '/modules/' registryUrl}}/packages"
     }
+
   ]
 }

--- a/staging/kf6-kio/kf6-kio.spec
+++ b/staging/kf6-kio/kf6-kio.spec
@@ -1,6 +1,8 @@
 %global framework kio
 
 %global stable_kf6 stable
+
+# renovate: datasource=yum repo=fedora-41-x86_64-updates/kf6-kio
 %global majmin_ver_kf6 6.8
 
 Name:    kf6-%{framework}

--- a/staging/kf6-kio/kf6-kio.spec
+++ b/staging/kf6-kio/kf6-kio.spec
@@ -2,7 +2,7 @@
 
 %global stable_kf6 stable
 
-# renovate: datasource=yum repo=fedora-41-x86_64-updates/kf6-kio
+# renovate: datasource=yum repo=fedora-41-x86_64-updates pkg=kf6-kio
 %global majmin_ver_kf6 6.8
 
 Name:    kf6-%{framework}


### PR DESCRIPTION
Part of #53. This PR adds a Renovate rule for the `kf6-kio` package that automatically pulls the latest version info from Fedora 41's update stream.

I manually tested it on a self-hosted Gitea instance. In the screenshots below, I rolled back the version from 6.8 to 6.7 for testing and the renovate bot was able to recognize that it was behind a version and open a PR. 

![Screenshot_20241205_154318](https://github.com/user-attachments/assets/04642a68-1535-4da8-bbcb-743d583a3a36)
![Screenshot_20241205_154352](https://github.com/user-attachments/assets/ba45eec9-04e2-453a-ac70-bbd5c4fb25db)
