### PR TITLE
fix(renovate): update rules for rpm-ostree and gsconnect

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -31,6 +31,11 @@
       "versioningTemplate": "loose",
       "registryUrlTemplate": "https://yum2npm.io/repos/{{replace '/' '/modules/' registryUrl}}/packages"
     }
-
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["rpm-ostree"],
+      "extractVersion": "^(?<version>\\d+\\.\\d+)",
+    }
   ]
 }

--- a/.github/test/renovate/test_renovate.py
+++ b/.github/test/renovate/test_renovate.py
@@ -32,6 +32,16 @@ TEST_CASES = {
        "path": "staging/scx-scheds/scx-scheds.spec",
        "match": r"Version:        1\.\d+\.\d+",
        "replace": r"Version:   1.0.4",
+    },
+    "rpm-ostree": {
+       "path": "staging/rpm-ostree/rpm-ostree.spec",
+       "match": r"Version: 202\d.\d",
+       "replace": r"Version:   2024.6",
+    },
+    "GSConnect/gnome-shell-extension-gsconnect": {
+       "path": "staging/gnome-shell-extension-gsconnect/gnome-shell-extension-gsconnect.spec",
+       "match": r"Version:\s+\d+",
+       "replace": r"Version: 57",
     }
 }
 

--- a/staging/gnome-shell-extension-gsconnect/gnome-shell-extension-gsconnect.spec
+++ b/staging/gnome-shell-extension-gsconnect/gnome-shell-extension-gsconnect.spec
@@ -5,7 +5,7 @@
 %global app_id org.gnome.Shell.Extensions.GSConnect
 
 Name:           gnome-shell-extension-gsconnect
-# renovate: datasource=github-releases depName=GSConnect/gnome-shell-extension-gsconnect
+# renovate: datasource=github-releases depName=GSConnect/gnome-shell-extension-gsconnect versioning=semver-major
 Version:        58
 Release:        1%{?dist}
 Summary:        KDE Connect implementation for GNOME Shell


### PR DESCRIPTION
This PR fixes a few issues with recently added renovate rules and adds tests for those rules to verify that they're working correctly.

## `rpm-ostree`
The versioning scheme for `rpm-ostree` is different from the standard rpm version scheme as seen in packages such as `fwupd`. For example, compare `rpm-ostree 2024.9` vs `fwupd 1.9.27`. We need to add a package-specific rule for `rpm-ostree` that uses this date-based versioning scheme.

## `GSConnect`
The github-releases rule we have defaults to a `semver` versioning scheme which requires at least a major and minor version component (e.g., `58.1`). The `GSConnect` versioning scheme only uses a single major version (e.g., `58`) which is more accurately captured by using the `semver-major` versioning scheme.

## Testing
The newly added test cases confirm that the current rules as written would not pick up new versions. With these changes, it is able to find updates.

```bash
> cd .github/test/renovate
> just
Working in /tmp/tmp.4pUJmHfLrc
DEBUG: Using RE2 regex engine
DEBUG: Parsing configs
DEBUG: Checking for config file in /usr/src/app/.github/renovate.json5
DEBUG: Converting GITHUB_COM_TOKEN into a global host rule

[ ... snip ... ]

DEBUG: Checking file package cache for expired items
DEBUG: Deleted 0 of 28 file cached entries in 13ms
Packages with updates:
{'fwupd', 'GSConnect/gnome-shell-extension-gsconnect', 'topgrade-rs/topgrade', 'sched-ext/scx', 'rpm-ostree', 'loft-sh/devpod', 'kf6-kio'}
passed
```