### PR TITLE
feat: add uupd to renovate tests

### DIFF
--- a/.github/test/renovate/test_renovate.py
+++ b/.github/test/renovate/test_renovate.py
@@ -42,6 +42,11 @@ TEST_CASES = {
        "path": "staging/gnome-shell-extension-gsconnect/gnome-shell-extension-gsconnect.spec",
        "match": r"Version:\s+\d+",
        "replace": r"Version: 57",
+    },
+    "ublue-os/uupd": {
+       "path": "staging/uupd/uupd.spec",
+       "match": r"Version:\s+\d+",
+       "replace": r"Version: 0.4",
     }
 }
 


### PR DESCRIPTION
This test confirms that a new minor version would indeed be picked up by renovate.

```bash
❯❯ just test-local
Working in /tmp/tmp.9qvNJjHV84
DEBUG: Using RE2 regex engine
DEBUG: Parsing configs
DEBUG: Checking for config file in /usr/src/app/.github/renovate.json5
DEBUG: Converting GITHUB_COM_TOKEN into a global host rule
DEBUG: File config

[ ... snip ...]

Packages with updates:
{'loft-sh/devpod', 'rpm-ostree', 'ublue-os/uupd', 'sched-ext/scx', 'GSConnect/gnome-shell-extension-gsconnect', 'fwupd', 'kf6-kio', 'topgrade-rs/topgrade'}
passed
```