### PR TITLE
chore: manually bump uupd version to 1.0.0

### DIFF
--- a/.github/test/renovate/test_renovate.py
+++ b/.github/test/renovate/test_renovate.py
@@ -45,8 +45,8 @@ TEST_CASES = {
     },
     "ublue-os/uupd": {
        "path": "staging/uupd/uupd.spec",
-       "match": r"Version:\s+\d+",
-       "replace": r"Version: 0.4",
+       "match": r"Version:\s+\d[^\s]+",
+       "replace": r"Version: 0.5.1",
     }
 }
 

--- a/staging/uupd/uupd.spec
+++ b/staging/uupd/uupd.spec
@@ -1,6 +1,6 @@
 Name:           uupd
 # renovate: datasource=github-releases depName=ublue-os/uupd
-Version:        0.5
+Version:        1.0.0
 Release:        0%{?dist}
 Summary:       Centralized update service/checker made for Universal Blue
 Vendor:        ublue-os


### PR DESCRIPTION
Because the versioning scheme of uupd was inconsistent in terms of how strictly it followed semver (i.e., 0.5 -> 0.5.1 -> 1.0.0), the latest renovate job on [Mend](https://developer.mend.io/github/ublue-os/packages/-/job/019400e8-8c07-713b-8fdb-a81be311b230) did not pick up the new version for uupd.

Now that the versioning scheme is following semver, hopefully renovate will be able to automatically detect these updates after manually bumping the version to a semver-compliant value of 1.0.0.