### PR TITLE
fix(bluefin, branding): build fails due to missing icons entry on faces

### DIFF
--- a/bluefin/branding/bluefin-branding.spec
+++ b/bluefin/branding/bluefin-branding.spec
@@ -51,6 +51,7 @@ Replacement logos for GNOME
 %files logos
 %attr(0755,root,root) %{_datadir}/pixmaps/fedora*
 %attr(0755,root,root) %{_datadir}/pixmaps/system-*
+%attr(0755,root,root) %{_datadir}/pixmaps/ublue-*
 
 %package cli-logos
 Summary:        Logos for CLI


### PR DESCRIPTION
This seems to generate no more errors locally: ![image](https://github.com/user-attachments/assets/6a381c7e-f9ff-4c27-ad4e-7259f0352f6c)

Sadly forgot to add this on the last commit