### PR TITLE
feat: add ublue-motd as a standalone script

### DIFF
--- a/ublue/motd/src/themes/blue.json
+++ b/ublue/motd/src/themes/blue.json
@@ -1,0 +1,88 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "33",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "color": "33",
+    "bold": true
+  },
+  "hr": {
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "bold": true
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/ublue/motd/src/themes/green.json
+++ b/ublue/motd/src/themes/green.json
@@ -1,0 +1,88 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "34",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "color": "34",
+    "bold": true
+  },
+  "hr": {
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "bold": true
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/ublue/motd/src/themes/orange.json
+++ b/ublue/motd/src/themes/orange.json
@@ -1,0 +1,88 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "208",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "color": "208",
+    "bold": true
+  },
+  "hr": {
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "bold": true
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/ublue/motd/src/themes/pink.json
+++ b/ublue/motd/src/themes/pink.json
@@ -1,0 +1,88 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "212",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "color": "212",
+    "bold": true
+  },
+  "hr": {
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "bold": true
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/ublue/motd/src/themes/purple.json
+++ b/ublue/motd/src/themes/purple.json
@@ -1,0 +1,88 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "165",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "color": "165",
+    "bold": true
+  },
+  "hr": {
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "bold": true
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/ublue/motd/src/themes/red.json
+++ b/ublue/motd/src/themes/red.json
@@ -1,0 +1,88 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "203",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "color": "203",
+    "bold": true
+  },
+  "hr": {
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "bold": true
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/ublue/motd/src/themes/slate.json
+++ b/ublue/motd/src/themes/slate.json
@@ -1,0 +1,88 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "104",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "color": "104",
+    "bold": true
+  },
+  "hr": {
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "bold": true
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/ublue/motd/src/themes/teal.json
+++ b/ublue/motd/src/themes/teal.json
@@ -1,0 +1,88 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "44",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "color": "44",
+    "bold": true
+  },
+  "hr": {
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "bold": true
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/ublue/motd/src/themes/yellow.json
+++ b/ublue/motd/src/themes/yellow.json
@@ -1,0 +1,88 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "220",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "color": "220",
+    "bold": true
+  },
+  "hr": {
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "bold": true
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/ublue/motd/src/ublue-motd
+++ b/ublue/motd/src/ublue-motd
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# set -x
+
+escape() {
+	sed 's/[&/\]/\\&/g' <<< "$1"
+}
+die() {
+	echo "$@" >&2
+	exit 1
+}
+
+get_config() {
+	MOTD_CONFIG_FILE="${MOTD_CONFIG_FILE:-/etc/ublue-os/motd.json}"
+	QUERY="$1"
+	FALLBACK="$2"
+	shift
+	shift
+	OUTPUT="$(jq -r "$QUERY" "$MOTD_CONFIG_FILE" 2>/dev/null || echo "$FALLBACK")"
+	if [ "$OUTPUT" == "null" ] ; then
+		echo "$FALLBACK"
+		return
+	fi
+	echo "$OUTPUT"
+}
+
+# Put all the configuration-specific variables here so that we can define exactly what is going to be on the config easier by just reading this section
+TIP_DIRECTORY="$(get_config '."tips-directory"' "/usr/share/ublue-os/motd/tips")"
+CHECK_OUTDATED="$(get_config '."check-outdated"' "true")"
+IMAGE_INFO="$(get_config '."image-info-file"' "/usr/share/ublue-os/image-info.json")"
+DEFAULT_THEME="$(get_config '."default-theme"' "slate")"
+TEMPLATE_FILE="$(get_config '."template-file"' "/usr/share/ublue-os/motd/template.md")"
+THEMES_DIRECTORY="$(get_config '."themes-directory"' "/usr/share/ublue-os/motd/themes")"
+# HOOKS_DIRECTORY="$(get_config '."hooks-directory"' "/usr/share/ublue-os/motd/hooks.d")"
+[ ! -f "$TEMPLATE_FILE" ] && die "Failed reading template file"
+
+TIP_FILE="$(find "$TIP_DIRECTORY" -iname "*.md" 2>/dev/null | shuf -n 1)"
+
+if [ "$CHECK_OUTDATED" == "true" ] ; then
+	IMAGE_DATE=$(rpm-ostree status --booted | sed -n 's/.*Timestamp: \(.*\)/\1/p')
+	IMAGE_DATE_SECONDS=$(date -d "$IMAGE_DATE" +%s)
+	CURRENT_SECONDS=$(date +%s)
+	DIFFERENCE=$((CURRENT_SECONDS - IMAGE_DATE_SECONDS))
+	ONE_MONTH=$((30 * 24 * 60 * 60))
+	if [ "$DIFFERENCE" -ge "$ONE_MONTH" ]; then
+		#shellcheck disable=2016
+		TIP='# 󰇻 Your current image is over 1 month old, run `ujust update`'
+	fi
+fi
+
+TIP="${TIP:-$(shuf -n 1 "$TIP_FILE")}"
+TIP_ESCAPED="󰋼 $(escape "$TIP")"
+
+KEY_WARN_FILE="/run/user-motd-sbkey-warn.md"
+[ -e $KEY_WARN_FILE ] && KEY_WARN="**WARNING**: $(cat $KEY_WARN_FILE)"
+KEY_WARN_ESCAPED=$(escape "$KEY_WARN")
+
+THEME=$(gsettings get org.gnome.desktop.interface accent-color 2>/dev/null || printf '%s' "\'$DEFAULT_THEME\'")
+THEME=${THEME//\'/}
+THEME=${MOTD_FORCE_THEME:-$THEME}
+
+IMAGE_NAME_ESCAPED="$(escape "$(jq -r '."image-name"' "$IMAGE_INFO")")"
+IMAGE_TAG_ESCAPED="$(escape "$(jq -r '."image-tag"' "$IMAGE_INFO")")"
+
+sed -e "s/%IMAGE_NAME%/$IMAGE_NAME_ESCAPED/g" \
+	-e "s/%IMAGE_TAG%/$IMAGE_TAG_ESCAPED/g" \
+	-e "s/%TIP%/$TIP_ESCAPED/g" \
+	-e "s/%KEY_WARN%/$KEY_WARN_ESCAPED/g" \
+	"$TEMPLATE_FILE" | tr '~' '\n' | /usr/bin/glow -s "${THEMES_DIRECTORY}/${THEME}.json" -w 78 -

--- a/ublue/motd/ublue-motd.spec
+++ b/ublue/motd/ublue-motd.spec
@@ -1,0 +1,31 @@
+%global debug_package %{nil}
+
+Name:           ublue-motd
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        MOTD scripts for Universal Blue images
+
+License:        Apache-2.0
+URL:            https://github.com/ublue-os/packages
+VCS:            {{{ git_dir_vcs }}}
+Source:         {{{ git_dir_pack }}}
+
+Requires:       glow
+
+%description
+MOTD script for Universal Blue
+
+%prep
+{{{ git_dir_setup_macro }}}
+
+%install
+install -Dm0755 ./src/ublue-motd %{buildroot}%{_libexecdir}/ublue-motd
+install -dm 0755 %{buildroot}%{_datadir}/ublue-os/motd/themes
+cp -rp ./src/themes/* %{buildroot}%{_datadir}/ublue-os/motd/themes
+
+%files
+%{_libexecdir}/ublue-motd
+%{_datadir}/ublue-os/motd/themes/*
+
+%changelog
+%autochangelog


### PR DESCRIPTION
This should make it possible to share the ublue-motd script as a package for all the images: it should also be extensible through a configuration file so that we dont need to have a separate script for each thing. This is the first release so I just tried to make it equal to the old one.
