### PR TITLE
ublue services

### DIFF
--- a/ublue/setup-services/src/polkit/20-privileged-user.rules
+++ b/ublue/setup-services/src/polkit/20-privileged-user.rules
@@ -1,0 +1,6 @@
+polkit.addRule(function(action, subject) {
+    if ((action.id == "org.ublue.policykit.privileged.user.setup") &&
+         subject.isInGroup("wheel")) {
+        return polkit.Result.YES;
+    }
+});

--- a/ublue/setup-services/src/polkit/org.ublue.privileged.user.setup.policy
+++ b/ublue/setup-services/src/polkit/org.ublue.privileged.user.setup.policy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+
+  <vendor>Universal Blue</vendor>
+  <vendor_url>https://github.com/ublue-os/</vendor_url>
+
+  <action id="org.ublue.policykit.privileged.user.setup">
+    <description>Allows certain user configuration tasks to run as root</description>
+    <icon_name>package-x-generic</icon_name>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>yes</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/ublue-privileged-user-setup</annotate>
+  </action>
+
+</policyconfig>

--- a/ublue/setup-services/src/profile/sbkey-notify-autostart.sh
+++ b/ublue/setup-services/src/profile/sbkey-notify-autostart.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+
+if test "$(id -u)" -gt "0" && test -d "$HOME"; then
+    if test ! -e "$HOME"/.config/autostart/sb-key-notify.desktop; then
+        mkdir -p "$HOME"/.config/autostart
+        cp -f /etc/skel/.config/autostart/sb-key-notify.desktop "$HOME"/.config/autostart
+    fi
+fi

--- a/ublue/setup-services/src/scripts/check-sb-key.sh
+++ b/ublue/setup-services/src/scripts/check-sb-key.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This script must be run as root." >&2
+  exit 1
+fi
+
+get_config() {
+    SETUP_CONFIG_FILE="${SETUP_CONFIG_FILE:-/etc/ublue-os/setup.json}"
+    QUERY="$1"
+    FALLBACK="$2"
+    shift
+    shift
+    OUTPUT="$(jq -r "$QUERY" "$SETUP_CONFIG_FILE" 2>/dev/null || echo "$FALLBACK")"
+    if [ "$OUTPUT" == "null" ] ; then
+        echo "$FALLBACK"
+        return
+    fi
+    echo "$OUTPUT"
+}
+
+WARNING_MSG="This machine has secure boot turned on, but you haven't enrolled Universal Blue's keys. Failing to enroll these before rebooting **may cause your system to fail to boot**. Follow [the documentation](https://docs.projectbluefin.io/introduction#secure-boot) ~for key enrollment information."
+KEY_WARN_FILE="/run/user-motd-sbkey-warn.md"
+KEY_DER_FILE="$(get_config '."der-path"' "/etc/pki/akmods/certs/akmods-ublue.der")"
+
+mokutil --sb-state | grep -q enabled
+SB_ENABLED=$?
+
+if [ $SB_ENABLED -ne 1 ]; then
+    echo "Secure Boot disabled. Skipping..."
+    exit 0
+fi
+
+if mokutil --test-key "$KEY_DER_FILE"; then 
+    echo "$WARNING_MSG" > $KEY_WARN_FILE
+else
+    [ -e $KEY_WARN_FILE ] && rm $KEY_WARN_FILE
+fi
+exit 0

--- a/ublue/setup-services/src/scripts/ublue-privileged-setup
+++ b/ublue/setup-services/src/scripts/ublue-privileged-setup
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+get_config() {
+	SETUP_CONFIG_FILE="${SETUP_CONFIG_FILE:-/etc/ublue-os/setup.json}"
+	QUERY="$1"
+	FALLBACK="$2"
+	shift
+	shift
+	OUTPUT="$(jq -r "$QUERY" "$SETUP_CONFIG_FILE" 2>/dev/null || echo "$FALLBACK")"
+	if [ "$OUTPUT" == "null" ] ; then
+		echo "$FALLBACK"
+		return
+	fi
+	echo "$OUTPUT"
+}
+
+PRIVILEGED_HOOKS_DIRECTORY="$(get_config '."privileged-hooks-directory"' "/usr/share/ublue-os/privileged-setup.hooks.d")"
+
+if [ -d "${PRIVILEGED_HOOKS_DIRECTORY}" ] ; then
+	bash ${PRIVILEGED_HOOKS_DIRECTORY}/*
+fi

--- a/ublue/setup-services/src/scripts/ublue-system-setup
+++ b/ublue/setup-services/src/scripts/ublue-system-setup
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+get_config() {
+	SETUP_CONFIG_FILE="${SETUP_CONFIG_FILE:-/etc/ublue-os/setup.json}"
+	QUERY="$1"
+	FALLBACK="$2"
+	shift
+	shift
+	OUTPUT="$(jq -r "$QUERY" "$SETUP_CONFIG_FILE" 2>/dev/null || echo "$FALLBACK")"
+	if [ "$OUTPUT" == "null" ] ; then
+		echo "$FALLBACK"
+		return
+	fi
+	echo "$OUTPUT"
+}
+
+SYSTEM_HOOKS_DIRECTORY="$(get_config '."system-hooks-directory"' "/usr/share/ublue-os/system-setup.hooks.d")"
+
+if [ -d "$SYSTEM_HOOKS_DIRECTORY" ] ; then
+	bash $SYSTEM_HOOKS_DIRECTORY/*
+fi

--- a/ublue/setup-services/src/scripts/ublue-user-setup
+++ b/ublue/setup-services/src/scripts/ublue-user-setup
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -x
+
+get_config() {
+	SETUP_CONFIG_FILE="${SETUP_CONFIG_FILE:-/etc/ublue-os/setup.json}"
+	QUERY="$1"
+	FALLBACK="$2"
+	shift
+	shift
+	OUTPUT="$(jq -r "$QUERY" "$SETUP_CONFIG_FILE" 2>/dev/null || echo "$FALLBACK")"
+	if [ "$OUTPUT" == "null" ] ; then
+		echo "$FALLBACK"
+		return
+	fi
+	echo "$OUTPUT"
+}
+
+USER_SETUP_VER="$(get_config '."setup-version"' "4")"
+USER_HOOKS_DIRECTORY="$(get_config '."user-hooks-directory"' "/usr/share/ublue-os/user-setup.hooks.d")"
+
+USER_SETUP_VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/user-setup"
+USER_SETUP_VER_RAN="$(cat "$USER_SETUP_VER_FILE")"
+
+mkdir -p "$(dirname "$USER_SETUP_VER_FILE")" || exit 1
+
+dirname "$USER_SETUP_VER_FILE"
+
+UBLUE_CONFIG_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/ublue"
+mkdir -p "$UBLUE_CONFIG_DIR"
+
+# Run script if updated
+if [[ -f "$USER_SETUP_VER_FILE" && "$USER_SETUP_VER" == "$USER_SETUP_VER_RAN" ]]; then
+  echo "Current user setup version has already run. Exiting..."
+  exit 0
+fi
+
+if [ -d "$USER_HOOKS_DIRECTORY" ] ; then
+  bash $USER_HOOKS_DIRECTORY/*
+fi
+
+pkexec bash /usr/libexec/ublue-privileged-setup
+
+# Prevent future executions
+echo "Writing state file"
+echo $USER_SETUP_VER > "$USER_SETUP_VER_FILE"

--- a/ublue/setup-services/src/scripts/ublue-user-setup
+++ b/ublue/setup-services/src/scripts/ublue-user-setup
@@ -16,7 +16,7 @@ get_config() {
 	echo "$OUTPUT"
 }
 
-USER_SETUP_VER="$(get_config '."setup-version"' "4")"
+USER_SETUP_VER="$(get_config '."setup-version"' "10")"
 USER_HOOKS_DIRECTORY="$(get_config '."user-hooks-directory"' "/usr/share/ublue-os/user-setup.hooks.d")"
 
 USER_SETUP_VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/user-setup"

--- a/ublue/setup-services/src/services/check-sb-key.service
+++ b/ublue/setup-services/src/services/check-sb-key.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Service to check for secure boot key enrollment
+
+[Service]
+ExecStart=/usr/libexec/check-sb-key.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/ublue/setup-services/src/services/ublue-system-setup.service
+++ b/ublue/setup-services/src/services/ublue-system-setup.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Configure system
+After=rpm-ostreed.service
+Before=systemd-user-sessions.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/ublue-system-setup
+
+[Install]
+WantedBy=multi-user.target

--- a/ublue/setup-services/src/services/ublue-user-setup.service
+++ b/ublue/setup-services/src/services/ublue-user-setup.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Configure system for current user
+
+[Service]
+Type=simple
+ExecStart=/usr/libexec/ublue-user-setup
+
+[Install]
+WantedBy=default.target

--- a/ublue/setup-services/ublue-setup-services.spec
+++ b/ublue/setup-services/ublue-setup-services.spec
@@ -1,0 +1,44 @@
+%global debug_package %{nil}
+
+Name:           ublue-setup-services
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        Universal Blue setup services
+
+License:        Apache-2.0
+URL:            https://github.com/ublue-os/packages
+VCS:            {{{ git_dir_vcs }}}
+Source:         {{{ git_dir_pack }}}
+
+%description
+Universal Blue setup scripts
+
+%prep
+{{{ git_dir_setup_macro }}}
+
+%install
+mkdir -p %{buildroot}{%{_libexecdir},%{_unitdir},%{_sysconfdir}/{polkit-1/{rules.d,actions},profile.d}}
+install -Dm0755 ./src/scripts/* %{buildroot}%{_libexecdir}
+install -Dpm0644 ./src/services/* %{buildroot}%{_unitdir}
+install -Dpm0644 ./src/polkit/*.rules %{buildroot}%{_sysconfdir}/polkit-1/rules.d
+install -Dpm0644 ./src/polkit/*.policy %{buildroot}%{_sysconfdir}/polkit-1/actions
+install -Dpm0755 ./src/profile/* %{buildroot}%{_sysconfdir}/profile.d
+
+%post
+%systemd_post ublue-user-setup.service
+%systemd_post ublue-system-setup.service
+
+%preun
+%systemd_preun ublue-user-setup.service
+%systemd_preun ublue-system-setup.service
+
+%files
+%{_libexecdir}/ublue-*
+%{_libexecdir}/check-*
+%{_sysconfdir}/polkit-1/rules.d/*
+%{_sysconfdir}/polkit-1/actions/*
+%{_sysconfdir}/profile.d/*
+%{_unitdir}/*.service
+
+%changelog
+%autochangelog

--- a/ublue/setup-services/ublue-setup-services.spec
+++ b/ublue/setup-services/ublue-setup-services.spec
@@ -10,6 +10,8 @@ URL:            https://github.com/ublue-os/packages
 VCS:            {{{ git_dir_vcs }}}
 Source:         {{{ git_dir_pack }}}
 
+BuildRequires:  systemd-rpm-macros
+
 %description
 Universal Blue setup scripts
 


### PR DESCRIPTION
- **fix(ublue, fastfetch): correctly source custom configuration file (#88)**
  

- **feat: add universal blue services for privileged and system setup**
  This is still not the best implementation, but it makes it so the images can put their stuff in /usr/share/ublue-os/user-setup.hooks.d instead of putting them all over the place like they are doing right now.
  It also implements the secure boot checking here ootb!
  

- **fix: bump user setup to 10 so that we get this update**
  

- **fix(ublue, setup-services): add systemd-rpm-macros because copr doesnt work without it**
  I didnt know my local environment had that package in it! Thats why the build wasnt working on COPR
  