### PR TITLE
fix: COPR build for ublue-setup-services + allow sb-check-key to be disabled

### DIFF
--- a/ublue/setup-services/src/scripts/check-sb-key.sh
+++ b/ublue/setup-services/src/scripts/check-sb-key.sh
@@ -22,12 +22,17 @@ get_config() {
 WARNING_MSG="This machine has secure boot turned on, but you haven't enrolled Universal Blue's keys. Failing to enroll these before rebooting **may cause your system to fail to boot**. Follow [the documentation](https://docs.projectbluefin.io/introduction#secure-boot) ~for key enrollment information."
 KEY_WARN_FILE="/run/user-motd-sbkey-warn.md"
 KEY_DER_FILE="$(get_config '."der-path"' "/etc/pki/akmods/certs/akmods-ublue.der")"
+IS_THIS_ENABLED="$(get_config '."check-secureboot"' "true")"
 
 mokutil --sb-state | grep -q enabled
 SB_ENABLED=$?
 
 if [ $SB_ENABLED -ne 1 ]; then
     echo "Secure Boot disabled. Skipping..."
+    exit 0
+fi
+
+if [ "$IS_THIS_ENABLED" == "false" ] ; then
     exit 0
 fi
 

--- a/ublue/setup-services/ublue-setup-services.spec
+++ b/ublue/setup-services/ublue-setup-services.spec
@@ -10,6 +10,8 @@ URL:            https://github.com/ublue-os/packages
 VCS:            {{{ git_dir_vcs }}}
 Source:         {{{ git_dir_pack }}}
 
+BuildRequires:  systemd-rpm-macros
+
 %description
 Universal Blue setup scripts
 


### PR DESCRIPTION
COPR build was failing because it was missing systemd-rpm-macros. I didnt even know this was on my local environment! Damn!

I also let the secureboot checker get disabled if we dont want it to work like on Achillobator right now