### PR TITLE
fix(ublue, fastfetch): make fastfetch only see files

### DIFF
--- a/ublue/fastfetch/src/ublue-fastfetch
+++ b/ublue/fastfetch/src/ublue-fastfetch
@@ -20,7 +20,7 @@ SHUFFLE_LOGO="$(get_config '."shuffle-logo"' "false")"
 LOGO_DIRECTORY="$(get_config '."logo-directory"' "/usr/share/ublue-os/fastfetch")"
 
 if [ "$SHUFFLE_LOGO" == "true" ] ; then
-  FETCH_LOGO="$(/usr/bin/find "$LOGO_DIRECTORY" | /usr/bin/shuf -n 1)"
+  FETCH_LOGO="$(/usr/bin/find "$LOGO_DIRECTORY" -type f | /usr/bin/shuf -n 1)"
   /usr/bin/fastfetch --logo "$FETCH_LOGO" --color "$(/usr/libexec/ublue-bling-fastfetch)" --config "$FASTFETCH_CONFIG"
 else
   /usr/bin/fastfetch --color "$(/usr/libexec/ublue-bling-fastfetch)" --config "$FASTFETCH_CONFIG"

--- a/ublue/fastfetch/ublue-fastfetch.spec
+++ b/ublue/fastfetch/ublue-fastfetch.spec
@@ -2,7 +2,7 @@
 
 Name:           ublue-fastfetch
 Version:        0.1.0
-Release:        2%{?dist}
+Release:        3%{?dist}
 Summary:        Fastfetch configuration for Universal Blue systems
 
 License:        Apache-2.0


### PR DESCRIPTION
If we let the find command see directories, the fastfetch sometimes will select the "symbols" folder during shuffling, making the logo default to the CentOS/Fedora logo.
