### PR TITLE
fix: ghost brew.sh file so that ublue-brew is installable on aurora/bluefin ootb

### DIFF
--- a/ublue/brew/ublue-brew.spec
+++ b/ublue/brew/ublue-brew.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-brew
-Version:        0.1.0
+Version:        0.1.1
 Release:        1%{?dist}
 Summary:        Homebrew integration for Universal Blue systems
 
@@ -34,7 +34,8 @@ cp -rp src/tmpfiles.d %{buildroot}%{_prefix}/lib
 %systemd_preun brew-setup.service
 
 %files
-%{_sysconfdir}/profile.d/brew*
+%ghost %{_sysconfdir}/profile.d/brew.sh
+%{_sysconfdir}/profile.d/brew-bash-completion.sh
 %{_datadir}/fish/vendor_conf.d/%{name}.fish
 %{_sysconfdir}/security/limits.d/*brew*.conf
 %{_unitdir}/brew-setup.service


### PR DESCRIPTION
Needed so that https://github.com/ublue-os/bluefin/pull/2135 can get merged without modifications to ublue-os-just