### PR TITLE
chore: bump kf6-kio to 6.10

### DIFF
--- a/staging/kf6-kio/kf6-kio.spec
+++ b/staging/kf6-kio/kf6-kio.spec
@@ -3,7 +3,7 @@
 %global stable_kf6 stable
 
 # renovate: datasource=yum repo=fedora-41-x86_64-updates pkg=kf6-kio
-%global majmin_ver_kf6 6.9
+%global majmin_ver_kf6 6.10
 
 Name:    kf6-%{framework}
 Version: %{majmin_ver_kf6}.0


### PR DESCRIPTION
Not sure why renovate didn't pick up this change.