### PR TITLE
fix: typo in bling.sh

### DIFF
--- a/ublue/bling/src/bling.sh
+++ b/ublue/bling/src/bling.sh
@@ -29,7 +29,7 @@ HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-/home/linuxbrew/.linuxbrew}"
 ATUIN_INIT_FLAGS=${ATUIN_INIT_FLAGS:-""}
 
 if [ "$(basename "$SHELL")" = "bash" ]; then
-    [ -f "/etc/profile.d/bash-preexec.sh" ] && . "${HOMEBREW_PREFIX}/etc/profile.d/bash-preexec.sh"
+    [ -f "/etc/profile.d/bash-preexec.sh" ] && . "/etc/profile.d/bash-preexec.sh"
     [ -f "/usr/share/bash-prexec" ] && . "/usr/share/bash-prexec" 
     [ -f "${HOMEBREW_PREFIX}/etc/profile.d/bash-preexec.sh" ] && . "${HOMEBREW_PREFIX}/etc/profile.d/bash-preexec.sh"
     [ "$(command -v starship)" ] && eval "$(starship init bash)"


### PR DESCRIPTION
It seems the intent was to source the file that we checked exists.

The file under the homebrew prefix is still sourced two lines below.