### PR TITLE
fix: make ublue-user-setup not handle versioning

### DIFF
--- a/ublue/setup-services/src/scripts/ublue-user-setup
+++ b/ublue/setup-services/src/scripts/ublue-user-setup
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -x
-
 get_config() {
 	SETUP_CONFIG_FILE="${SETUP_CONFIG_FILE:-/etc/ublue-os/setup.json}"
 	QUERY="$1"
@@ -16,31 +14,10 @@ get_config() {
 	echo "$OUTPUT"
 }
 
-USER_SETUP_VER="$(get_config '."setup-version"' "10")"
 USER_HOOKS_DIRECTORY="$(get_config '."user-hooks-directory"' "/usr/share/ublue-os/user-setup.hooks.d")"
-
-USER_SETUP_VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/user-setup"
-USER_SETUP_VER_RAN="$(cat "$USER_SETUP_VER_FILE")"
-
-mkdir -p "$(dirname "$USER_SETUP_VER_FILE")" || exit 1
-
-dirname "$USER_SETUP_VER_FILE"
-
-UBLUE_CONFIG_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/ublue"
-mkdir -p "$UBLUE_CONFIG_DIR"
-
-# Run script if updated
-if [[ -f "$USER_SETUP_VER_FILE" && "$USER_SETUP_VER" == "$USER_SETUP_VER_RAN" ]]; then
-  echo "Current user setup version has already run. Exiting..."
-  exit 0
-fi
 
 if [ -d "$USER_HOOKS_DIRECTORY" ] ; then
   bash $USER_HOOKS_DIRECTORY/*
 fi
 
 pkexec bash /usr/libexec/ublue-privileged-setup
-
-# Prevent future executions
-echo "Writing state file"
-echo $USER_SETUP_VER > "$USER_SETUP_VER_FILE"

--- a/ublue/setup-services/ublue-setup-services.spec
+++ b/ublue/setup-services/ublue-setup-services.spec
@@ -1,8 +1,8 @@
 %global debug_package %{nil}
 
 Name:           ublue-setup-services
-Version:        0.1.0
-Release:        3%{?dist}
+Version:        0.1.1
+Release:        1%{?dist}
 Summary:        Universal Blue setup services
 
 License:        Apache-2.0


### PR DESCRIPTION
Letting the image handle script versioning is the only way we can reliably do versioning per-script, otherwise they will either all run, or none will ever run