### PR TITLE
fix: make privileged setup not run all the time

### DIFF
--- a/ublue/setup-services/src/scripts/ublue-user-setup
+++ b/ublue/setup-services/src/scripts/ublue-user-setup
@@ -16,8 +16,7 @@ get_config() {
 
 USER_HOOKS_DIRECTORY="$(get_config '."user-hooks-directory"' "/usr/share/ublue-os/user-setup.hooks.d")"
 
+# Privileged setup can be called via user services
 if [ -d "$USER_HOOKS_DIRECTORY" ] ; then
   bash $USER_HOOKS_DIRECTORY/*
 fi
-
-pkexec bash /usr/libexec/ublue-privileged-setup

--- a/ublue/setup-services/ublue-setup-services.spec
+++ b/ublue/setup-services/ublue-setup-services.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-setup-services
-Version:        0.1.1
+Version:        0.1.2
 Release:        1%{?dist}
 Summary:        Universal Blue setup services
 


### PR DESCRIPTION
Without this the privileged part will run on every boot. Thats absolutely we dont want to happen. Privileged user setup should be handled by image scripts too
