### PR TITLE
  fix(setup-services): make it so the services run when graphical.target runs

### DIFF
--- a/ublue/setup-services/src/user-services/ublue-user-setup.service
+++ b/ublue/setup-services/src/user-services/ublue-user-setup.service
@@ -6,4 +6,4 @@ Type=simple
 ExecStart=/usr/libexec/ublue-user-setup
 
 [Install]
-WantedBy=graphical.target
+WantedBy=graphical-session.target

--- a/ublue/setup-services/src/user-services/ublue-user-setup.service
+++ b/ublue/setup-services/src/user-services/ublue-user-setup.service
@@ -6,4 +6,4 @@ Type=simple
 ExecStart=/usr/libexec/ublue-user-setup
 
 [Install]
-WantedBy=default.target
+WantedBy=graphical.target

--- a/ublue/setup-services/ublue-setup-services.spec
+++ b/ublue/setup-services/ublue-setup-services.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-setup-services
-Version:        0.1.2
+Version:        0.1.3
 Release:        1%{?dist}
 Summary:        Universal Blue setup services
 


### PR DESCRIPTION
This should make it so they run when the desktop is about to run instead of in a random init process during plymouth. Should make it so things like privileged-setup works without artificial delays