### PR TITLE
feat: add package building check on github actions

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -2,46 +2,71 @@ name: Build package in CI
 
 on:
   pull_request:
-    branches:
-      - main
 
 jobs:
   changed_files:
     runs-on: ubuntu-latest
-    name: Test changed-files
+    name: Get changed files
+    outputs:
+      all_changed_files: ${{ steps.changed-package-files.outputs.all_changed_files }}
+      any_changed: ${{ steps.changed-package-files.outputs.any_changed }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Just
-        uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
 
       - name: Get directories with spec files
         id: specdirs
         run: |
-          find . -type f -iname '*.spec' -exec 'dirname' '{}' ';' 2>/dev/null | xargs -I{} echo "{}/**" > ./files.txt
+          FILESLIST=./files.txt
+          # The extra xargs there is so that the changed-files action can find all the files
+          find . -type f -iname '*.spec' -exec 'dirname' '{}' ';' 2>/dev/null | xargs -I{} echo "{}/**" > $FILESLIST
+          echo "fileslist=$FILESLIST" >> $GITHUB_OUTPUT
 
       - name: Get all changed files from package directores
         id: changed-package-files
         uses: tj-actions/changed-files@v45
         with:
-          files_from_source_file: ./files.txt
+          files_from_source_file: ${{ steps.specdirs.outputs.fileslist }}
 
-      - name: List all changed files markdown files
-        if: steps.changed-package-files.outputs.any_changed == 'true'
+  build_packages:
+    runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    needs: changed_files
+    name: Test changed-files
+    if: needs.changed_files.outputs.any_changed == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        # FIXME: add suport for aarch64 ublue-builder container
+        platform: ["amd64"]
+        # These are our target environments
+        # FIXME: renovate rule for this would be awesome
+        chroot: ["fedora-41", "epel-10"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        if: matrix.platform == 'arm64'
+        run: |
+          sudo apt update -y
+          sudo apt install -y \
+            podman
+
+      - name: Setup Just
+        uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
+
+      - name: Build all changed packages
         env:
-          ALL_CHANGED_FILES: ${{ steps.changed-package-files.outputs.all_changed_files }}
+          ALL_CHANGED_FILES: ${{ needs.changed_files.outputs.all_changed_files }}
         run: |
           set -x
           just=$(which just)
 
           mkdir -p containers
-
           CONTAINERS_DIR=./containers
           export CONTAINERS_DIR
 
           for file in ${ALL_CHANGED_FILES}; do
             for spec in $(dirname $file)/*.spec ; do
-               $just build $spec
+               $just build $spec -r ${{ matrix.chroot }}-$(arch)
             done
           done
 

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,0 +1,47 @@
+name: Build package in CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  changed_files:
+    runs-on: ubuntu-latest
+    name: Test changed-files
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Just
+        uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
+
+      - name: Get directories with spec files
+        id: specdirs
+        run: |
+          find . -type f -iname '*.spec' -exec 'dirname' '{}' ';' 2>/dev/null | xargs -I{} echo "{}/**" > ./files.txt
+
+      - name: Get all changed files from package directores
+        id: changed-package-files
+        uses: tj-actions/changed-files@v45
+        with:
+          files_from_source_file: ./files.txt
+
+      - name: List all changed files markdown files
+        if: steps.changed-package-files.outputs.any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-package-files.outputs.all_changed_files }}
+        run: |
+          set -x
+          just=$(which just)
+
+          mkdir -p containers
+
+          CONTAINERS_DIR=./containers
+          export CONTAINERS_DIR
+
+          for file in ${ALL_CHANGED_FILES}; do
+            for spec in $(dirname $file)/*.spec ; do
+               $just build $spec
+            done
+          done
+

--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,4 +1,4 @@
-name: Build package in CI
+name: Build packages in CI
 
 on:
   pull_request:
@@ -10,12 +10,14 @@ jobs:
     outputs:
       all_changed_files: ${{ steps.changed-package-files.outputs.all_changed_files }}
       any_changed: ${{ steps.changed-package-files.outputs.any_changed }}
+      specs: ${{ steps.packages.outputs.specs }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Get directories with spec files
         id: specdirs
         run: |
+          set -x
           FILESLIST=./files.txt
           # The extra xargs there is so that the changed-files action can find all the files
           find . -type f -iname '*.spec' -exec 'dirname' '{}' ';' 2>/dev/null | xargs -I{} echo "{}/**" > $FILESLIST
@@ -27,10 +29,26 @@ jobs:
         with:
           files_from_source_file: ${{ steps.specdirs.outputs.fileslist }}
 
+      - name: Get all packages that need to be rebuilt
+        id: packages
+        if: steps.changed-package-files.outputs.any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-package-files.outputs.all_changed_files }}
+        run: |
+          set -x
+
+          MATRIX="{\"specs\":[]}"
+          for file in ${ALL_CHANGED_FILES}; do
+            for spec in $(dirname $file)/*.spec ; do
+              MATRIX=$(echo $MATRIX | jq ".specs += [\"$spec\"]")
+            done
+          done
+          echo "specs=$(echo $MATRIX | jq -c '.specs')" >> $GITHUB_OUTPUT
+
   build_packages:
     runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     needs: changed_files
-    name: Test changed-files
+    name: Build RPM package
     if: needs.changed_files.outputs.any_changed == 'true'
     strategy:
       fail-fast: false
@@ -40,6 +58,7 @@ jobs:
         # These are our target environments
         # FIXME: renovate rule for this would be awesome
         chroot: ["fedora-41", "epel-10"]
+        spec: ${{ fromJson(needs.changed_files.outputs.specs) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -53,9 +72,7 @@ jobs:
       - name: Setup Just
         uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
 
-      - name: Build all changed packages
-        env:
-          ALL_CHANGED_FILES: ${{ needs.changed_files.outputs.all_changed_files }}
+      - name: Build ${{ matrix.spec }}
         run: |
           set -x
           just=$(which just)
@@ -63,10 +80,4 @@ jobs:
           mkdir -p containers
           CONTAINERS_DIR=./containers
           export CONTAINERS_DIR
-
-          for file in ${ALL_CHANGED_FILES}; do
-            for spec in $(dirname $file)/*.spec ; do
-               $just build $spec -r ${{ matrix.chroot }}-$(arch)
-            done
-          done
-
+          $just build ${{matrix.spec}} -r ${{ matrix.chroot }}-$(arch)

--- a/Justfile
+++ b/Justfile
@@ -17,11 +17,13 @@ renovate dry-run="lookup" log-level="debug":
 
 build $spec *MOCK_ARGS:
     #!/usr/bin/env bash
+    set -x
     mkdir -p mock
     # Passes your user to the container and adds it to the mock group else rpkg will not be able to recognize local changes
     # Mock also needs to be called unprivileged apparently
+    CONTAINERS_DIR="${CONTAINERS_DIR:-/var/lib/containers}"
     sudo podman run --privileged --rm -it \
-        -v /var/lib/containers:/var/lib/containers:z \
+        -v $CONTAINERS_DIR:/var/lib/containers:z \
         -v ./mock:/var/lib/mock:Z \
         -v .:/tmp/sources:Z \
         -w /tmp/sources \

--- a/ublue/bling/ublue-bling.spec
+++ b/ublue/bling/ublue-bling.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-bling
-Version:        0.1.2
+Version:        0.1.3
 Release:        1%{?dist}
 Summary:        Universal Blue Bling CLI setup scripts
 

--- a/ublue/bling/ublue-bling.spec
+++ b/ublue/bling/ublue-bling.spec
@@ -2,7 +2,7 @@
 
 Name:           ublue-bling
 Version:        0.1.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Universal Blue Bling CLI setup scripts
 
 License:        Apache-2.0


### PR DESCRIPTION
This adds a check to make sure that modified rpms (and their files) actually build before we push them to COPR