### PR TITLE
Update ublue-fastfetch to pass arguments to fastfetch

### DIFF
--- a/ublue/fastfetch/src/ublue-fastfetch
+++ b/ublue/fastfetch/src/ublue-fastfetch
@@ -21,9 +21,9 @@ LOGO_DIRECTORY="$(get_config '."logo-directory"' "/usr/share/ublue-os/fastfetch"
 
 if [ "$SHUFFLE_LOGO" == "true" ] ; then
   FETCH_LOGO="$(/usr/bin/find "$LOGO_DIRECTORY" -type f | /usr/bin/shuf -n 1)"
-  /usr/bin/fastfetch --logo "$FETCH_LOGO" --color "$(/usr/libexec/ublue-bling-fastfetch)" --config "$FASTFETCH_CONFIG"
+  /usr/bin/fastfetch --logo "$FETCH_LOGO" --color "$(/usr/libexec/ublue-bling-fastfetch)" --config "$FASTFETCH_CONFIG" "$@"
 else
-  /usr/bin/fastfetch --color "$(/usr/libexec/ublue-bling-fastfetch)" --config "$FASTFETCH_CONFIG"
+  /usr/bin/fastfetch --color "$(/usr/libexec/ublue-bling-fastfetch)" --config "$FASTFETCH_CONFIG" "$@"
 fi
 
 

--- a/ublue/fastfetch/ublue-fastfetch.spec
+++ b/ublue/fastfetch/ublue-fastfetch.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-fastfetch
-Version:        0.1.2
+Version:        0.1.3
 Release:        1%{?dist}
 Summary:        Fastfetch configuration for Universal Blue systems
 


### PR DESCRIPTION
Allow passing arguments to fastfetch, such as '-l none' for posting output online.