### PR TITLE
fix(ublue-brew): make setup service always create the linuxbrew folder before setting up brew

### DIFF
--- a/ublue/brew/src/systemd/brew-setup.service
+++ b/ublue/brew/src/systemd/brew-setup.service
@@ -8,6 +8,7 @@ ConditionPathExists=!/var/home/linuxbrew/.linuxbrew
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/mkdir -p /tmp/homebrew
+ExecStart=/usr/bin/mkdir -p /var/home/linuxbrew
 ExecStart=/usr/bin/tar --zstd -xvf /usr/share/homebrew.tar.zst -C /tmp/homebrew
 ExecStart=/usr/bin/cp -R -n /tmp/homebrew/home/linuxbrew/.linuxbrew /var/home/linuxbrew
 ExecStart=/usr/bin/chown -R 1000:1000 /var/home/linuxbrew

--- a/ublue/brew/ublue-brew.spec
+++ b/ublue/brew/ublue-brew.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-brew
-Version:        0.1.1
+Version:        0.1.2
 Release:        1%{?dist}
 Summary:        Homebrew integration for Universal Blue systems
 


### PR DESCRIPTION
This fixes a race condition where the brew home folder isnt created, usually because of people using shared home directories. This should make it so /home/linuxbrew is created before copying the contents of the brew tarball, thus users should always have the `/home/linuxbrew/.linuxbrew` folder applied properly