### PR TITLE
fix(kf6-kio): add missing plugins from upstream spec

### DIFF
--- a/staging/kf6-kio/kf6-kio.spec
+++ b/staging/kf6-kio/kf6-kio.spec
@@ -189,6 +189,7 @@ Developer Documentation files for %{name} for use with KDevelop or QtCreator.
 %{_kf6_plugindir}/kio/
 %{_kf6_plugindir}/kded/
 %{_kf6_plugindir}/kiod/
+%{_kf6_plugindir}/kio_dnd/
 %{_kf6_datadir}/kf6/searchproviders/*.desktop
 %{_kf6_datadir}/applications/*.desktop
 %{_datadir}/dbus-1/services/org.kde.*.service


### PR DESCRIPTION
We are missing this line compared to the spec in Fedora's official package.

```bash
 diff \
  <(curl -L https://raw.githubusercontent.com/ublue-os/packages/refs/heads/main/staging/kf6-kio/kf6-kio.spec) \
  <(curl -L https://src.fedoraproject.org/rpms/kf6-kio/raw/rawhide/f/kf6-kio.spec)
```

```diff
< %global stable_kf6 stable
< 
< # renovate: datasource=yum repo=fedora-41-x86_64-updates pkg=kf6-kio
< %global majmin_ver_kf6 6.11
< 
9,10c4,5
< Version: %{majmin_ver_kf6}.0
< Release: 2%{?dist}.switcheroo.{{{ git_dir_version }}}
---
> Version: 6.11.0
> Release: 1%{?dist}
30,31d24
< # https://invent.kde.org/frameworks/kio/-/merge_requests/1556
< Patch201: 1556.patch
191a185
> %{_kf6_plugindir}/kio_dnd/
```