### PR TITLE
ci(brew-tarball): allow releasing tarballs via workflow dispatch

### DIFF
--- a/.github/workflows/brew-tarball.yml
+++ b/.github/workflows/brew-tarball.yml
@@ -1,6 +1,7 @@
 name: Generate Homebrew tarball and Release
 
-on:
+on
+  workflow_dispatch:
   schedule:
     - cron: "0 1 * * TUE" # Every Tuesday at 1am UTC
   merge_group:


### PR DESCRIPTION
We need to rebuild it and I forgot to add this to the action