### PR TITLE
fix(ublue-motd): make sure that dconf has a fallback for the accent color theme

### DIFF
--- a/ublue/motd/src/ublue-changelog
+++ b/ublue/motd/src/ublue-changelog
@@ -19,10 +19,14 @@ TARGET_URL="$(get_config '."target-url"' "invalid")"
 JQ_EXPRESSION="$(get_config '."jq-expression"' ".body")"
 THEMES_DIRECTORY="$(get_config '."themes-directory"' "/usr/share/ublue-os/motd/themes")"
 
-THEME=$(dconf read /org/gnome/desktop/interface/accent-color 2>/dev/null || printf '%s' "\'$DEFAULT_THEME\'")
+THEME=$(dconf read /org/gnome/desktop/interface/accent-color 2>/dev/null || echo -e "$DEFAULT_THEME")
+# Dconf will fail if the accent-color has not been changed yet
+if [ "$THEME" == "" ] ; then
+	# Gsettings will not update if the system's schemas have not been configured properly
+	THEME=$(gsettings get org.gnome.desktop.interface accent-color 2>/dev/null || echo -e "$DEFAULT_THEME")
+fi
 THEME=${THEME//\'/}
 THEME=${CHANGELOG_FORCE_THEME:-$THEME}
-
 
 curl -s "$TARGET_URL" | \
 	jq -r "$JQ_EXPRESSION" | \

--- a/ublue/motd/ublue-motd.spec
+++ b/ublue/motd/ublue-motd.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-motd
-Version:        0.2.3
+Version:        0.2.4
 Release:        1%{?dist}
 Summary:        MOTD scripts for Universal Blue images
 


### PR DESCRIPTION
ublue-changelogs crashed on my system telling me that there was no themes directory, this should fix it as we didnt apply the dconf/gsettings accent color workaround for ublue-changelogs still
