### PR TITLE
feat: powerstat should be recommended not required

### DIFF
--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -12,7 +12,7 @@ Source:         {{{ git_dir_pack }}}
 BuildArch:      noarch
 Requires:       just
 Requires:       ublue-os-luks
-Requires:       powerstat
+Recommends:       powerstat
 
 %global sub_name %{lua:t=string.gsub(rpm.expand("%{NAME}"), "^ublue%-os%-", ""); print(t)}
 


### PR DESCRIPTION
this helps in situations like using this on CentOS based Bluefin-LTS where powerstat isn't in EPEL yet.