### PR TITLE
 fix(just): incorrect config files in configure-broadcom-wl

### DIFF
--- a/packages/ublue-os-just/src/recipes/50-akmods.just
+++ b/packages/ublue-os-just/src/recipes/50-akmods.just
@@ -24,7 +24,7 @@ configure-broadcom-wl ACTION="prompt":
       sudo rm -f /etc/modprobe.d/default-disable-broadcom-wl.conf
       echo "${bold}Enabled${normal} Broadcom Wireless, please reboot for changes to take effect"
     elif [ "${OPTION,,}" == "disable" ]; then
-      sudo bash -c '> /etc/modules-load.d/broadcom-wl-blacklist.conf'
-      sudo bash -c 'echo "blacklist wl" > /etc/modules-load.d/default-disable-broadcom-wl.conf'
+      sudo ln -sf /dev/null /etc/modprobe.d/broadcom-wl-blacklist.conf
+      sudo bash -c 'echo "blacklist wl" > /etc/modprobe.d/default-disable-broadcom-wl.conf'
       echo "${bold}Disabled${normal} Broadcom Wireless, please reboot for changes to take effect"
     fi

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -1,6 +1,6 @@
 Name:           ublue-os-just
 Vendor:         ublue-os
-Version:        0.39
+Version:        0.40
 Release:        1%{?dist}
 Summary:        ublue-os just integration
 License:        MIT


### PR DESCRIPTION
Direct port from https://github.com/ublue-os/config/pull/350. This fixes the wl module getting disabled incorrectly due to the wrong directory being used for the modprobe configuration