### PR TITLE
chore: create backup container signing keys

### DIFF
--- a/packages/ublue-os-signing/src/etc/pki/containers/ublue-os-backup.pub
+++ b/packages/ublue-os-signing/src/etc/pki/containers/ublue-os-backup.pub
@@ -1,0 +1,4 @@
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERTMY78++NW5twobx8+Fwd+wqrTwd
+U8+Jv+r7QS+jwbl4VZ4GDbHjz01dRsqTbzdRjlYK+ERXTm9NfJJ5IlFFtw==
+-----END PUBLIC KEY-----

--- a/packages/ublue-os-signing/src/usr/etc/containers/policy.json
+++ b/packages/ublue-os-signing/src/usr/etc/containers/policy.json
@@ -32,7 +32,10 @@
             "ghcr.io/ublue-os": [
                 {
                     "type": "sigstoreSigned",
-                    "keyPath": "/etc/pki/containers/ublue-os.pub",
+                    "keyPaths": [
+                        "/etc/pki/containers/ublue-os.pub",
+                        "/etc/pki/containers/ublue-os-backup.pub"
+                    ],
                     "signedIdentity": {
                         "type": "matchRepository"
                     }

--- a/packages/ublue-os-signing/ublue-os-signing.spec
+++ b/packages/ublue-os-signing/ublue-os-signing.spec
@@ -1,6 +1,6 @@
 Name:           ublue-os-signing
 Vendor:         ublue-os
-Version:        0.4
+Version:        0.5
 Release:        1%{?dist}
 Summary:        Signing files and keys for Universal Blue
 License:        Apache-2.0
@@ -36,13 +36,18 @@ install -Dm0644 -t %{buildroot}%{_datadir}/%{VENDOR}/%{sub_name}/%{_sysconfdir}/
 %{_datadir}/%{VENDOR}/%{sub_name}/%{_sysconfdir}/containers/registries.d/quay.io-toolbx-images.yaml
 %{_datadir}/%{VENDOR}/%{sub_name}/%{_sysconfdir}/pki/containers/quay.io-toolbx-images.pub
 %{_datadir}/%{VENDOR}/%{sub_name}/%{_sysconfdir}/pki/containers/ublue-os.pub
+%{_datadir}/%{VENDOR}/%{sub_name}/%{_sysconfdir}/pki/containers/ublue-os-backup.pub
 %{_exec_prefix}/etc/containers/policy.json
 %{_sysconfdir}/containers/registries.d/ublue-os.yaml
 %{_sysconfdir}/containers/registries.d/quay.io-toolbx-images.yaml
 %{_sysconfdir}/pki/containers/quay.io-toolbx-images.pub
 %{_sysconfdir}/pki/containers/ublue-os.pub
+%{_sysconfdir}/pki/containers/ublue-os-backup.pub
 
 %changelog
+* Sun Feb 23 2025 Robert Sturla <robertsturla@outlook.com> - 0.5
+- Created backup container signing keys
+
 * Thu Aug 08 2024 Kyle Gospodnetich <me@kylegospodneti.ch> - 0.4
 - Moved policy.json back to /usr/etc/ temporarily
 


### PR DESCRIPTION
Closes https://github.com/ublue-os/main/issues/703

These keys will be unused until a time when we need to rotate.  When we do need to rotate, we can change the priv key in GitHub Actions, and these will be accepted by the signing policy.
