### PR TITLE
feat(ublue-polkit-rules): add polkit rules for yubikeys

### DIFF
--- a/packages/ublue-polkit-rules/src/org.debian.pcsc-lite.access_card.rules
+++ b/packages/ublue-polkit-rules/src/org.debian.pcsc-lite.access_card.rules
@@ -1,0 +1,16 @@
+// allow members of the wheel group to access gpg cards via pcscd service
+// this is needed for access to yubikey devices
+// installation details from https://github.com/drduh/YubiKey-Guide/issues/376
+
+polkit.addRule(function(action, subject) {
+        if (action.id == "org.debian.pcsc-lite.access_card" &&
+                subject.isInGroup("wheel")) {
+                return polkit.Result.YES;
+        }
+});
+polkit.addRule(function(action, subject) {
+        if (action.id == "org.debian.pcsc-lite.access_pcsc" &&
+                subject.isInGroup("wheel")) {
+                return polkit.Result.YES;
+        }
+});

--- a/packages/ublue-polkit-rules/ublue-polkit-rules.spec
+++ b/packages/ublue-polkit-rules/ublue-polkit-rules.spec
@@ -1,0 +1,30 @@
+Name:           ublue-polkit-rules
+Version:        0.1.0
+Release:        1%{?dist}
+Summary:        Polkit rules for Universal Blue projects
+
+License:        Apache-2.0
+URL:            https://github.com/ublue-os/packages
+VCS:            {{{ git_dir_vcs }}}
+Source0:        {{{ git_dir_pack }}}
+
+BuildArch:      noarch
+
+%description
+Polkit Rules for Universal Blue
+
+%prep
+{{{ git_dir_setup_macro }}}
+
+%build
+
+%install
+install -Dm0644 -t %{buildroot}%{_sysconfdir}/polkit-1/rules.d/ src/*.rules
+
+%check
+
+%files
+%{_sysconfdir}/polkit-1/rules.d/*.rules
+
+%changelog
+%autochangelog


### PR DESCRIPTION
Port from https://github.com/ublue-os/config/pull/231. Adds a package specifically for polkit rules we might want.

Fixes: #209 
