### PR TITLE
chore: move all ublue-os packages to Apache-2.0

### DIFF
--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -3,7 +3,7 @@ Vendor:         ublue-os
 Version:        0.39
 Release:        1%{?dist}
 Summary:        ublue-os just integration
-License:        MIT
+License:        Apache-2.0
 URL:            https://github.com/ublue-os/packages
 VCS:            {{{ git_dir_vcs }}}
 Source:         {{{ git_dir_pack }}}

--- a/packages/ublue-os-luks/ublue-os-luks.spec
+++ b/packages/ublue-os-luks/ublue-os-luks.spec
@@ -3,7 +3,7 @@ Vendor:         ublue-os
 Version:        0.3
 Release:        1%{?dist}
 Summary:        ublue-os scripts for simplified LUKS usage
-License:        MIT
+License:        Apache-2.0
 URL:            https://github.com/ublue-os/packages
 VCS:            {{{ git_dir_vcs }}}
 Source:         {{{ git_dir_pack }}}

--- a/packages/ublue-os-signing/ublue-os-signing.spec
+++ b/packages/ublue-os-signing/ublue-os-signing.spec
@@ -3,7 +3,7 @@ Vendor:         ublue-os
 Version:        0.4
 Release:        1%{?dist}
 Summary:        Signing files and keys for Universal Blue
-License:        MIT
+License:        Apache-2.0
 URL:            https://github.com/ublue-os/packages
 VCS:            {{{ git_dir_vcs }}}
 Source:         {{{ git_dir_pack }}}

--- a/packages/ublue-os-udev-rules/ublue-os-udev-rules.spec
+++ b/packages/ublue-os-udev-rules/ublue-os-udev-rules.spec
@@ -11,7 +11,7 @@ Version:        0.9
 Release:        1%{?dist}
 Summary:        Additional udev files for device support
 
-License:        MIT
+License:        Apache-2.0
 URL:            https://github.com/ublue-os/packages
 
 BuildArch:      noarch

--- a/packages/ublue-os-update-services/ublue-os-update-services.spec
+++ b/packages/ublue-os-update-services/ublue-os-update-services.spec
@@ -3,7 +3,7 @@ Vendor:         ublue-os
 Version:        0.91
 Release:        1%{?dist}
 Summary:        Automatic updates for rpm-ostree and flatpak
-License:        MIT
+License:        Apache-2.0
 URL:            https://github.com/ublue-os/packages
 VCS:            {{{ git_dir_vcs }}}
 Source:         {{{ git_dir_pack }}}


### PR DESCRIPTION
Afaik this needs to be agreed upon by all the contributors for those packages. Better to PR this earlier than later at least.

Fixes: #217 