### PR TITLE
fix(ublue-os-just): make 60-custom.just an optional import

### DIFF
--- a/packages/ublue-os-just/src/recipes/60-custom.just
+++ b/packages/ublue-os-just/src/recipes/60-custom.just
@@ -1,2 +1,0 @@
-# vim: set ft=make :
-# This file can be modified downstream to add custom just commands

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -1,6 +1,6 @@
 Name:           ublue-os-just
 Vendor:         ublue-os
-Version:        0.40
+Version:        0.41
 Release:        1%{?dist}
 Summary:        ublue-os just integration
 License:        Apache-2.0
@@ -39,6 +39,7 @@ install -Dpm0644 ./src/header.just "%{buildroot}%{_datadir}/%{VENDOR}/justfile"
 for justfile in %{buildroot}%{_datadir}/%{VENDOR}/%{sub_name}/*.just; do
     echo "import \"%{_datadir}/%{VENDOR}/%{sub_name}/$(basename ${justfile})\"" >> "%{buildroot}%{_datadir}/%{VENDOR}/justfile"
 done
+echo "import? \"%{_datadir}/%{VENDOR}/%{sub_name}/60-custom.just\"" >> "%{buildroot}%{_datadir}/%{VENDOR}/justfile"
 
 # Add global "ujust" script to run just with --unstable
 install -Dpm0755 ./src/ujust %{buildroot}%{_bindir}/ujust

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -80,6 +80,10 @@ just --completions zsh | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/zsh/si
 chmod 644 %{_datadir}/zsh/site-functions/_ujust
 
 %changelog
+* Wed Feb 26 2025 Robert Sturla <robertsturla@outlook.com> - 0.41
+- Make 60-custom.just an optional import
+- Remove default 60-custom.just from the package
+
 * Mon Feb 17 2025 Tulip Blossom <tulilirockz@outlook.com> - 0.39
 - Remove ublue-os-just.sh from /etc/profile.d
 


### PR DESCRIPTION
Makes 60-custom.just an optional import, and remove the default one.  

This allows bluefin-lts to COPY the custom justfile without it being overwritten by the ublue-os-just install.

Optional imports are documented [here](https://github.com/casey/just#:~:text=Imports%20may%20be,foo/bar.just%27).