### PR TITLE
fix(ublue-user-setup): make privileged/user/system scripts run + ensure systemd service is run only by human users

### DIFF
--- a/packages/ublue-setup-services/src/scripts/ublue-privileged-setup
+++ b/packages/ublue-setup-services/src/scripts/ublue-privileged-setup
@@ -15,7 +15,14 @@ get_config() {
 }
 
 PRIVILEGED_HOOKS_DIRECTORY="$(get_config '."privileged-hooks-directory"' "/usr/share/ublue-os/privileged-setup.hooks.d")"
+HOOKS_VERBOSE="${HOOKS_VERBOSE:-$(get_config '."verbose"' "false")}"
+
+if [ "${HOOKS_VERBOSE}" == "true" ] ; then
+	set -x
+fi
 
 if [ -d "${PRIVILEGED_HOOKS_DIRECTORY}" ] ; then
-	bash ${PRIVILEGED_HOOKS_DIRECTORY}/*
+	for script in $PRIVILEGED_HOOKS_DIRECTORY/* ; do
+		bash $script
+	done
 fi

--- a/packages/ublue-setup-services/src/scripts/ublue-system-setup
+++ b/packages/ublue-setup-services/src/scripts/ublue-system-setup
@@ -15,7 +15,15 @@ get_config() {
 }
 
 SYSTEM_HOOKS_DIRECTORY="$(get_config '."system-hooks-directory"' "/usr/share/ublue-os/system-setup.hooks.d")"
+HOOKS_VERBOSE="${HOOKS_VERBOSE:-$(get_config '."verbose"' "false")}"
 
-if [ -d "$SYSTEM_HOOKS_DIRECTORY" ] ; then
-	bash $SYSTEM_HOOKS_DIRECTORY/*
+if [ "${HOOKS_VERBOSE}" == "true" ] ; then
+	set -x
 fi
+
+if [ -d "${SYSTEM_HOOKS_DIRECTORY}" ] ; then
+	for script in $SYSTEM_HOOKS_DIRECTORY/* ; do
+		bash $script
+	done
+fi
+

--- a/packages/ublue-setup-services/src/scripts/ublue-user-setup
+++ b/packages/ublue-setup-services/src/scripts/ublue-user-setup
@@ -15,6 +15,11 @@ get_config() {
 }
 
 USER_HOOKS_DIRECTORY="$(get_config '."user-hooks-directory"' "/usr/share/ublue-os/user-setup.hooks.d")"
+HOOKS_VERBOSE="${HOOKS_VERBOSE:-$(get_config '."verbose"' "false")}"
+
+if [ "${HOOKS_VERBOSE}" == "true" ] ; then
+	set -x
+fi
 
 # Privileged setup can be called via user services
 if [ -d "$USER_HOOKS_DIRECTORY" ] ; then

--- a/packages/ublue-setup-services/src/scripts/ublue-user-setup
+++ b/packages/ublue-setup-services/src/scripts/ublue-user-setup
@@ -18,5 +18,7 @@ USER_HOOKS_DIRECTORY="$(get_config '."user-hooks-directory"' "/usr/share/ublue-o
 
 # Privileged setup can be called via user services
 if [ -d "$USER_HOOKS_DIRECTORY" ] ; then
-  bash $USER_HOOKS_DIRECTORY/*
+	for script in $USER_HOOKS_DIRECTORY/* ; do
+		bash $script
+	done
 fi

--- a/packages/ublue-setup-services/src/user-services/ublue-user-setup.service
+++ b/packages/ublue-setup-services/src/user-services/ublue-user-setup.service
@@ -1,8 +1,11 @@
 [Unit]
 Description=Configure system for current user
+Wants=network-online.target
+After=network-online.target
+ConditionUser=!@system
 
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=/usr/libexec/ublue-user-setup
 
 [Install]

--- a/packages/ublue-setup-services/ublue-setup-services.spec
+++ b/packages/ublue-setup-services/ublue-setup-services.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-setup-services
-Version:        0.1.3
+Version:        0.1.4
 Release:        1%{?dist}
 Summary:        Universal Blue setup services
 


### PR DESCRIPTION
The `Condition=!@system` stuff I got straight from https://github.com/ublue-os/bluefin/pull/2199. These should make it so the scripts _actually run_ instead of accidentally running `bash script1.sh script2.sh`