### PR TITLE
feat: add helper script for ublue-setup-scripts on downstreams

### DIFF
--- a/packages/ublue-setup-services/src/lib/libsetup.sh
+++ b/packages/ublue-setup-services/src/lib/libsetup.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+SETUP_CHECKER_FILE="${SETUP_CHECKER_FILE:-$HOME/.local/share/ublue/setup_versioning.json}"
+# This lock is necessary so that multiple services must not modify the same file at the same time
+SETUP_CHECKER_LOCK="${SETUP_CHECKER_LOCK:-"${SETUP_CHECKER_FILE}.lck"}"
+
+function delete-version-lock() {
+  rm -r "${SETUP_CHECKER_LOCK}"
+}
+
+# Meant to be used at the start of any setup service script. Will version your script accordingly on $SETUP_CHECKER_FILE
+# :target_versioning_name: Whatever you want to name your versioning tag. Please keep it always the same
+# :type_of_service: Must be either `user`, `privileged`, or `system`
+# :version: Target version to check/apply to your file
+#
+# Meant to be used as follows (or similar):
+# version-script tailscale user 1 || exit 0
+function version-script() {
+  TARGET_VERSIONING_NAME=$1
+  TYPE_OF_SERVICE=$2
+  VERSION=$3
+  shift
+  shift
+  shift
+
+  if [ ! -e "${SETUP_CHECKER_FILE}" ] ; then
+    mkdir -p "$(dirname "${SETUP_CHECKER_FILE}")"
+    echo "{}" > "${SETUP_CHECKER_FILE}"
+  fi
+
+  while [ -e "${SETUP_CHECKER_LOCK}" ] ; do
+    echo "WARN: Sleeping because checker lock exists"
+    sleep 5
+  done
+  touch "${SETUP_CHECKER_LOCK}"
+  trap delete-version-lock EXIT
+  if [ "$(jq -r -c ".version.${TYPE_OF_SERVICE}.\"${TARGET_VERSIONING_NAME}\"" "${SETUP_CHECKER_FILE}")" == "${VERSION}" ] ; then
+    echo "Exiting as current version (${VERSION}) for ${TYPE_OF_SERVICE}-${TARGET_VERSIONING_NAME} is the same as latest version recorded on ${SETUP_CHECKER_FILE}"
+    return 1
+  fi
+  ANNOYING_JQ_WORKAROUND=$(mktemp)
+  jq ".version.${TYPE_OF_SERVICE}.\"${TARGET_VERSIONING_NAME}\" = \"${VERSION}\"" "${SETUP_CHECKER_FILE}" >"${ANNOYING_JQ_WORKAROUND}"
+  mv "${ANNOYING_JQ_WORKAROUND}" "${SETUP_CHECKER_FILE}"
+  set +x
+  return 0
+}

--- a/packages/ublue-setup-services/ublue-setup-services.spec
+++ b/packages/ublue-setup-services/ublue-setup-services.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-setup-services
-Version:        0.1.3
+Version:        0.1.5
 Release:        1%{?dist}
 Summary:        Universal Blue setup services
 
@@ -19,15 +19,15 @@ Universal Blue setup scripts
 {{{ git_dir_setup_macro }}}
 
 %install
-mkdir -p %{buildroot}{%{_bindir},%{_libexecdir},%{_unitdir},%{_prefix}/lib/systemd/user,%{_sysconfdir}/{polkit-1/{rules.d,actions},profile.d}}
-install -Dm0755 ./src/scripts/* %{buildroot}%{_libexecdir}
-install -Dm0755 ./src/bin/* %{buildroot}%{_bindir}
-install -Dpm0644 ./src/services/* %{buildroot}%{_unitdir}
-install -Dpm0644 ./src/user-services/* %{buildroot}%{_prefix}/lib/systemd/user/
-install -Dpm0644 ./src/polkit/*.rules %{buildroot}%{_sysconfdir}/polkit-1/rules.d
-install -Dpm0644 ./src/polkit/*.policy %{buildroot}%{_sysconfdir}/polkit-1/actions
-install -Dpm0755 ./src/profile/* %{buildroot}%{_sysconfdir}/profile.d
-cp -rp ./src/skel %{buildroot}%{_sysconfdir}
+install -Dm0755 -t %{buildroot}%{_libexecdir}/ ./src/scripts/*
+install -Dm0755 -t %{buildroot}%{_bindir}/ ./src/bin/*
+install -Dm0644 -t %{buildroot}%{_unitdir}/ ./src/services/*.service
+install -Dm0644 -t %{buildroot}%{_prefix}/lib/systemd/user/ ./src/user-services/*.service
+install -Dm0644 -t %{buildroot}%{_sysconfdir}/polkit-1/rules.d/ ./src/polkit/*.rules 
+install -Dm0644 -t %{buildroot}%{_sysconfdir}/polkit-1/actions/ ./src/polkit/*.policy
+install -Dm0755 -t %{buildroot}%{_sysconfdir}/profile.d/ ./src/profile/*.sh
+install -Dm0644 -t %{buildroot}%{_libdir}/ublue/setup-services/ ./src/lib/libsetup.sh
+install -Dm0644 -t %{buildroot}%{_sysconfdir}/skel/.config/autostart/ src/skel/.config/autostart/*.desktop
 
 %post
 %systemd_post ublue-user-setup.service
@@ -39,12 +39,13 @@ cp -rp ./src/skel %{buildroot}%{_sysconfdir}
 
 %files
 %{_bindir}/sb*
+%{_libdir}/ublue/setup-services/lib*.sh
 %{_libexecdir}/ublue-*
 %{_libexecdir}/check-*
-%config(noreplace) %{_sysconfdir}/polkit-1/rules.d/*
-%config(noreplace) %{_sysconfdir}/polkit-1/actions/*
-%config(noreplace) %{_sysconfdir}/profile.d/*
-%config(noreplace) %{_sysconfdir}/skel/.config/autostart/*
+%{_sysconfdir}/polkit-1/rules.d/*
+%{_sysconfdir}/polkit-1/actions/*
+%{_sysconfdir}/profile.d/*
+%{_sysconfdir}/skel/.config/autostart/*.desktop
 %{_unitdir}/*.service
 %{_prefix}/lib/systemd/user/*.service
 

--- a/packages/ublue-setup-services/ublue-setup-services.spec
+++ b/packages/ublue-setup-services/ublue-setup-services.spec
@@ -26,7 +26,7 @@ install -Dm0644 -t %{buildroot}%{_prefix}/lib/systemd/user/ ./src/user-services/
 install -Dm0644 -t %{buildroot}%{_sysconfdir}/polkit-1/rules.d/ ./src/polkit/*.rules 
 install -Dm0644 -t %{buildroot}%{_sysconfdir}/polkit-1/actions/ ./src/polkit/*.policy
 install -Dm0755 -t %{buildroot}%{_sysconfdir}/profile.d/ ./src/profile/*.sh
-install -Dm0644 -t %{buildroot}%{_libdir}/ublue/setup-services/ ./src/lib/libsetup.sh
+install -Dm0644 -t %{buildroot}%{_exec_prefix}/lib/ublue/setup-services/ ./src/lib/libsetup.sh
 install -Dm0644 -t %{buildroot}%{_sysconfdir}/skel/.config/autostart/ src/skel/.config/autostart/*.desktop
 
 %post
@@ -39,7 +39,7 @@ install -Dm0644 -t %{buildroot}%{_sysconfdir}/skel/.config/autostart/ src/skel/.
 
 %files
 %{_bindir}/sb*
-%{_libdir}/ublue/setup-services/lib*.sh
+%{_exec_prefix}/lib/ublue/setup-services/lib*.sh
 %{_libexecdir}/ublue-*
 %{_libexecdir}/check-*
 %{_sysconfdir}/polkit-1/rules.d/*


### PR DESCRIPTION
This will allow us, on downstreams, to version scripts much easier because we can just use a single function that will allow/disallow running the hooks on version changes

```sh
#!/usr/bin/env bash
source ./libsetup.sh

version-script test user 1 || exit 0

echo "works first time"
```

This should only output "works first time" at the first time the script is ran
