### PR TITLE
ci: force homebrew tarball to only build weekly, and not on pull request

### DIFF
--- a/.github/workflows/brew-tarball.yml
+++ b/.github/workflows/brew-tarball.yml
@@ -4,10 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 1 * * TUE" # Every Tuesday at 1am UTC
-  merge_group:
-  pull_request:
-    paths:
-      - ./Justfile
 
 jobs:
   generate_and_push:


### PR DESCRIPTION
We have lots more releases than we should. This should limit the homebrew tarball building just to weekly builds