### PR TITLE
fix(ublue-setup-services): allow privileged setup to be executed by wheel group without password

### DIFF
--- a/packages/ublue-setup-services/src/polkit/20-privileged-user-setup.rules
+++ b/packages/ublue-setup-services/src/polkit/20-privileged-user-setup.rules
@@ -1,0 +1,10 @@
+polkit.addRule(function(action,subject) {
+    if ( (action.id == "org.freedesktop.policykit.exec") &&
+         (action.lookup("program") == "/usr/libexec/ublue-privileged-setup") &&
+         (subject.isInGroup("wheel") ) ) {
+      return polkit.Result.YES;
+    }
+
+    return polkit.Result.NOT_HANDLED;
+  }
+);

--- a/packages/ublue-setup-services/src/polkit/20-privileged-user.rules
+++ b/packages/ublue-setup-services/src/polkit/20-privileged-user.rules
@@ -1,6 +1,0 @@
-polkit.addRule(function(action, subject) {
-    if ((action.id == "org.ublue.policykit.privileged.user.setup") &&
-         subject.isInGroup("wheel")) {
-        return polkit.Result.YES;
-    }
-});

--- a/packages/ublue-setup-services/src/polkit/org.ublue.privileged.user.setup.policy
+++ b/packages/ublue-setup-services/src/polkit/org.ublue.privileged.user.setup.policy
@@ -15,7 +15,7 @@
       <allow_inactive>yes</allow_inactive>
       <allow_active>yes</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/ublue-privileged-user-setup</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/libexec/ublue-privileged-setup</annotate>
   </action>
 
 </policyconfig>


### PR DESCRIPTION
Made this into a single PR since this is necessary for the stuff to work on Bluefin LTS + having two PRs makes it so it conflicts and acks get dismissed.

Testing this should be just: `cp (rules) /etc/polkit-1/rules.d/oldrules-i-forgot && systemctl restart polkit` for the polkit rules.

![image](https://github.com/user-attachments/assets/c2d72743-76bf-4213-8c3a-87acb7dbab8f)
