### PR TITLE
fix(ublue-setup-services): use simple type for service + remove locking

### DIFF
--- a/packages/ublue-setup-services/src/lib/libsetup.sh
+++ b/packages/ublue-setup-services/src/lib/libsetup.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
 
 SETUP_CHECKER_FILE="${SETUP_CHECKER_FILE:-$HOME/.local/share/ublue/setup_versioning.json}"
-# This lock is necessary so that multiple services must not modify the same file at the same time
-SETUP_CHECKER_LOCK="${SETUP_CHECKER_LOCK:-"${SETUP_CHECKER_FILE}.lck"}"
-
-function delete-version-lock() {
-  rm -r "${SETUP_CHECKER_LOCK}"
-}
 
 # Meant to be used at the start of any setup service script. Will version your script accordingly on $SETUP_CHECKER_FILE
 # :target_versioning_name: Whatever you want to name your versioning tag. Please keep it always the same
@@ -28,12 +22,6 @@ function version-script() {
     echo "{}" > "${SETUP_CHECKER_FILE}"
   fi
 
-  while [ -e "${SETUP_CHECKER_LOCK}" ] ; do
-    echo "WARN: Sleeping because checker lock exists"
-    sleep 5
-  done
-  touch "${SETUP_CHECKER_LOCK}"
-  trap delete-version-lock EXIT
   if [ "$(jq -r -c ".version.${TYPE_OF_SERVICE}.\"${TARGET_VERSIONING_NAME}\"" "${SETUP_CHECKER_FILE}")" == "${VERSION}" ] ; then
     echo "Exiting as current version (${VERSION}) for ${TYPE_OF_SERVICE}-${TARGET_VERSIONING_NAME} is the same as latest version recorded on ${SETUP_CHECKER_FILE}"
     return 1

--- a/packages/ublue-setup-services/src/services/ublue-system-setup.service
+++ b/packages/ublue-setup-services/src/services/ublue-system-setup.service
@@ -4,8 +4,7 @@ After=rpm-ostreed.service
 Before=systemd-user-sessions.service
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
+Type=simple
 ExecStart=/usr/libexec/ublue-system-setup
 
 [Install]

--- a/packages/ublue-setup-services/src/user-services/ublue-user-setup.service
+++ b/packages/ublue-setup-services/src/user-services/ublue-user-setup.service
@@ -5,7 +5,7 @@ After=network-online.target
 ConditionUser=!@system
 
 [Service]
-Type=oneshot
+Type=simple
 ExecStart=/usr/libexec/ublue-user-setup
 
 [Install]

--- a/packages/ublue-setup-services/ublue-setup-services.spec
+++ b/packages/ublue-setup-services/ublue-setup-services.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-setup-services
-Version:        0.1.5
+Version:        0.1.6
 Release:        1%{?dist}
 Summary:        Universal Blue setup services
 

--- a/packages/ublue-setup-services/ublue-setup-services.spec
+++ b/packages/ublue-setup-services/ublue-setup-services.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-setup-services
-Version:        0.1.6
+Version:        0.1.7
 Release:        1%{?dist}
 Summary:        Universal Blue setup services
 


### PR DESCRIPTION
This ensures that the graphical-session target will not get locked up if something makes the ublue-user-setup/system-setup services break for whatever reason. The locking mechanism is also not very useful as it just brings more ways for the services to get permanently stuck, and it doesnt even help out that much with multiple scripts modifiying the version state