### PR TITLE
feat(justfile): add overlay recipe with sysext for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ mock/
 rpmbuild/
 brew-out/
 arch_skipped
+overlays/


### PR DESCRIPTION
This will allow us to test packages easier and in a persistent manner via `systemd-sysext` by automatically creating layers based on the selected RPMs. This _REQUIRES_ systemd 257 as before that we didnt get the selinux patch for sysext. This sets selinux contexts automatically for the RPMs too so they should be able to mount/run just fine by default

The expected workflow is:
- just build (specfile)
- just overlay ./mock/(chroot)/results/(my rpm).rpm