### PR TITLE
feat: fully functional media-automount

### DIFF
--- a/packages/ublue-os-media-automount-udev/99-media-automount.rules
+++ b/packages/ublue-os-media-automount-udev/99-media-automount.rules
@@ -11,8 +11,11 @@ SUBSYSTEM!="block",                             GOTO="media_automount_end"
 # Exit if is in fstab...
 PROGRAM=="/usr/libexec/is_in_fstab.sh /dev/%k", RESULT=="yes", GOTO="media_automount_end"
 
-# ... or if is not a supported filesystem
+# ... or if is not a supported filesystem...
 ENV{ID_FS_TYPE}!="btrfs|ext4", GOTO="media_automount_end"
+
+# ... or if does not have a label
+ENV{ID_FS_LABEL}!="?*", GOTO="media_automount_end"
 
 # Add mounting options
 ENV{ID_FS_TYPE}=="btrfs", ENV{SYSTEMD_MOUNT_OPTIONS}="defaults,noatime,lazytime,commit=120,discard=async,compress-force=zstd:1,space_cache=v2,nofail"

--- a/packages/ublue-os-media-automount-udev/99-media-automount.rules
+++ b/packages/ublue-os-media-automount-udev/99-media-automount.rules
@@ -18,7 +18,7 @@ ENV{ID_FS_TYPE}!="btrfs|ext4", GOTO="media_automount_end"
 ENV{ID_FS_LABEL}!="?*", GOTO="media_automount_end"
 
 # Add mounting options
-ENV{ID_FS_TYPE}=="btrfs", ENV{SYSTEMD_MOUNT_OPTIONS}="defaults,noatime,lazytime,commit=120,discard=async,compress-force=zstd:1,space_cache=v2,nofail"
+ENV{ID_FS_TYPE}=="btrfs", ENV{SYSTEMD_MOUNT_OPTIONS}="defaults,noatime,lazytime,commit=120,discard=async,compress-force=zstd:1,space_cache=v2,nofail,rw,users,exec"
 ENV{ID_FS_TYPE}=="ext4", ENV{SYSTEMD_MOUNT_OPTIONS}="defaults,noatime,errors=remount-ro,nofail,rw,users,exec"
 
 # Mount the device

--- a/packages/ublue-os-media-automount-udev/99-media-automount.rules
+++ b/packages/ublue-os-media-automount-udev/99-media-automount.rules
@@ -15,12 +15,12 @@ PROGRAM=="/usr/libexec/is_in_fstab.sh /dev/%k", RESULT=="yes", GOTO="media_autom
 ENV{ID_FS_TYPE}!="btrfs|ext4", GOTO="media_automount_end"
 
 # Add mounting options
-ENV{SYSTEMD_MOUNT_WHERE}="/run/media/media-automount/%E{ID_FS_UUID}"
 ENV{ID_FS_TYPE}=="btrfs", ENV{SYSTEMD_MOUNT_OPTIONS}="defaults,noatime,lazytime,commit=120,discard=async,compress-force=zstd:1,space_cache=v2,nofail"
 ENV{ID_FS_TYPE}=="ext4", ENV{SYSTEMD_MOUNT_OPTIONS}="defaults,noatime,errors=remount-ro,nofail,rw,users,exec"
 
 # Mount the device
-ACTION=="add", RUN+="/usr/bin/systemd-mount --no-block -A --discover /dev/%k"
+ACTION=="add", \
+RUN+="/usr/bin/systemd-mount --no-block --collect --discover /dev/%k"
 
 # End of rule
 LABEL="media_automount_end"

--- a/packages/ublue-os-media-automount-udev/is_in_fstab.sh
+++ b/packages/ublue-os-media-automount-udev/is_in_fstab.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -eo pipefail
 
+PATH="/usr/bin:/sbin:$PATH"
+
 dev="$(findfs "$1")"
 while read -r _what _; do
     [[ $_what =~ ^#.* ]] && continue
     [[ $(findfs $"$_what") == "$dev" ]] && { echo "yes"; exit 0; }
 done </etc/fstab
-echo "no" && exit 1
+echo "no" && exit 0

--- a/packages/ublue-os-media-automount-udev/media-automount.conf
+++ b/packages/ublue-os-media-automount-udev/media-automount.conf
@@ -1,0 +1,1 @@
+L /run/media/media-automount - - - - /run/media/system

--- a/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
+++ b/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
@@ -1,6 +1,6 @@
 Name:           ublue-os-media-automount-udev
 Vendor:         ublue-os
-Version:        0.6
+Version:        0.7
 Release:        1%{?dist}
 Summary:        udev rules to mount non-removable disk partitions
 
@@ -24,14 +24,19 @@ Supplements:    systemd-udev
 %install
 install -p -Dm0644 ./99-media-automount.rules %{buildroot}%{_exec_prefix}/lib/udev/rules.d/99-media-automount.rules
 install -p -Dm0755 ./is_in_fstab.sh %{buildroot}%{_libexecdir}/is_in_fstab.sh
+install -p -Dm0644 ./media-automount.conf %{buildroot}%{_tmpfilesdir}/media-automount.conf
 
 %check
 
 %files
 %{_exec_prefix}/lib/udev/rules.d/99-media-automount.rules
 %{_libexecdir}/is_in_fstab.sh
+%{_tmpfilesdir}/media-automount.conf
 
 %changelog
+* Wed Mar 12 2025 Zeglius <33781398+Zeglius@users.noreply.github.com> - 0.7
+- Add /run/media/media-automount symlink for compatibility
+
 * Wed Mar 12 2025 Zeglius <33781398+Zeglius@users.noreply.github.com> - 0.6
 - Add missing mount options to btrfs partitions
 

--- a/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
+++ b/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
@@ -12,6 +12,7 @@ Source0:        {{{ git_dir_pack }}}
 
 BuildArch:      noarch
 Supplements:    systemd-udev
+BuildRequires:  systemd-rpm-macros
 
 %description
 %{summary}
@@ -22,14 +23,14 @@ Supplements:    systemd-udev
 %build
 
 %install
-install -p -Dm0644 ./99-media-automount.rules %{buildroot}%{_exec_prefix}/lib/udev/rules.d/99-media-automount.rules
+install -p -Dm0644 ./99-media-automount.rules %{buildroot}%{_udevrulesdir}/99-media-automount.rules
 install -p -Dm0755 ./is_in_fstab.sh %{buildroot}%{_libexecdir}/is_in_fstab.sh
 install -p -Dm0644 ./media-automount.conf %{buildroot}%{_tmpfilesdir}/media-automount.conf
 
 %check
 
 %files
-%{_exec_prefix}/lib/udev/rules.d/99-media-automount.rules
+%{_udevrulesdir}/99-media-automount.rules
 %{_libexecdir}/is_in_fstab.sh
 %{_tmpfilesdir}/media-automount.conf
 

--- a/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
+++ b/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
@@ -1,6 +1,6 @@
 Name:           ublue-os-media-automount-udev
 Vendor:         ublue-os
-Version:        0.5
+Version:        0.6
 Release:        1%{?dist}
 Summary:        udev rules to mount non-removable disk partitions
 
@@ -32,6 +32,9 @@ install -p -Dm0755 ./is_in_fstab.sh %{buildroot}%{_libexecdir}/is_in_fstab.sh
 %{_libexecdir}/is_in_fstab.sh
 
 %changelog
+* Wed Mar 12 2025 Zeglius <33781398+Zeglius@users.noreply.github.com> - 0.6
+- Add missing mount options to btrfs partitions
+
 * Wed Mar 12 2025 Zeglius <33781398+Zeglius@users.noreply.github.com> - 0.5
 - Only mount labeled partitions
 

--- a/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
+++ b/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
@@ -1,6 +1,6 @@
 Name:           ublue-os-media-automount-udev
 Vendor:         ublue-os
-Version:        0.1
+Version:        0.3
 Release:        1%{?dist}
 Summary:        udev rules to mount non-removable disk partitions
 
@@ -32,6 +32,9 @@ install -p -Dm0755 ./is_in_fstab.sh %{buildroot}%{_libexecdir}/is_in_fstab.sh
 %{_libexecdir}/is_in_fstab.sh
 
 %changelog
+* Wed Mar 12 2025 Zeglius <33781398+Zeglius@users.noreply.github.com> - 0.3
+- Dont error out in is_in_fstab.sh
+
 * Mon Mar 10 2025 Zeglius <33781398+Zeglius@users.noreply.github.com> - 0.2
 - Add missing permissions and use 'exit' instead of 'return' in is_in_fstab.sh
 

--- a/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
+++ b/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
@@ -1,6 +1,6 @@
 Name:           ublue-os-media-automount-udev
 Vendor:         ublue-os
-Version:        0.4
+Version:        0.5
 Release:        1%{?dist}
 Summary:        udev rules to mount non-removable disk partitions
 
@@ -32,6 +32,9 @@ install -p -Dm0755 ./is_in_fstab.sh %{buildroot}%{_libexecdir}/is_in_fstab.sh
 %{_libexecdir}/is_in_fstab.sh
 
 %changelog
+* Wed Mar 12 2025 Zeglius <33781398+Zeglius@users.noreply.github.com> - 0.5
+- Only mount labeled partitions
+
 * Wed Mar 12 2025 Zeglius <33781398+Zeglius@users.noreply.github.com> - 0.4
 - Load rule the latest and fetch UUID with lsblk
 

--- a/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
+++ b/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
@@ -1,6 +1,6 @@
 Name:           ublue-os-media-automount-udev
 Vendor:         ublue-os
-Version:        0.3
+Version:        0.4
 Release:        1%{?dist}
 Summary:        udev rules to mount non-removable disk partitions
 
@@ -22,16 +22,19 @@ Supplements:    systemd-udev
 %build
 
 %install
-install -p -Dm0644 ./60-media-automount.rules %{buildroot}%{_exec_prefix}/lib/udev/rules.d/60-media-automount.rules
+install -p -Dm0644 ./99-media-automount.rules %{buildroot}%{_exec_prefix}/lib/udev/rules.d/99-media-automount.rules
 install -p -Dm0755 ./is_in_fstab.sh %{buildroot}%{_libexecdir}/is_in_fstab.sh
 
 %check
 
 %files
-%{_exec_prefix}/lib/udev/rules.d/60-media-automount.rules
+%{_exec_prefix}/lib/udev/rules.d/99-media-automount.rules
 %{_libexecdir}/is_in_fstab.sh
 
 %changelog
+* Wed Mar 12 2025 Zeglius <33781398+Zeglius@users.noreply.github.com> - 0.4
+- Load rule the latest and fetch UUID with lsblk
+
 * Wed Mar 12 2025 Zeglius <33781398+Zeglius@users.noreply.github.com> - 0.3
 - Dont error out in is_in_fstab.sh
 


### PR DESCRIPTION
- **fix(ublue-os-media-automount-udev): Dont error out in is_in_fstab.sh**
- **fix(ublue-os-media-automount-udev): Load rule the latest and fetch UUID with lsblk**
- **fix(ublue-os-media-automount-udev): Only mount labeled partitions**
- **fix(ublue-os-media-automount-udev): Add missing mount options to btrfs partitions**
- **fix(ublue-os-media-automount-udev): Add /run/media/media-automount symlink for compatibility**
- **chore(ublue-os-media-automount-udev): Use systemd-rpm-macros**
