### PR TITLE
docs: Add documentation link after enabling bling

### DIFF
--- a/packages/ublue-bling/src/ublue-bling
+++ b/packages/ublue-bling/src/ublue-bling
@@ -183,7 +183,7 @@ function main() {
             trap ctrl_c SIGINT
             add-bling "${shell}"
             printf "%s%sInstallation Complete%s ... please close and reopen your terminal!" "${green}" "${bold}" "${normal}"
-	        printf "Check out the documentation at: https://docs.projectbluefin.io/bluefin-dx#bluefin-cli\n"
+	    printf "Check out the documentation at: https://docs.projectbluefin.io/bluefin-dx#bluefin-cli\n"
 	    exit 0
         ;;
         "disable")

--- a/packages/ublue-bling/src/ublue-bling
+++ b/packages/ublue-bling/src/ublue-bling
@@ -183,7 +183,8 @@ function main() {
             trap ctrl_c SIGINT
             add-bling "${shell}"
             printf "%s%sInstallation Complete%s ... please close and reopen your terminal!" "${green}" "${bold}" "${normal}"
-            exit 0
+	        printf "Check out the documentation at: https://docs.projectbluefin.io/bluefin-dx#bluefin-cli\n"
+	    exit 0
         ;;
         "disable")
             if ! is-bling-installed "${shell}"; then


### PR DESCRIPTION
This PR adds a link to the bling-cli documentation right after bling is activated, helping users access more information about its usage.