### PR TITLE
Fix ANSI code for unbold formatting; \e -> \033 for compatibility.

### DIFF
--- a/packages/ublue-os-just/src/lib-ujust/libformatting.sh
+++ b/packages/ublue-os-just/src/lib-ujust/libformatting.sh
@@ -20,7 +20,7 @@ declare -r hidden=$'\033[8m'
 ########
 declare -r normal=$'\033[0m'
 declare -r n="$normal"
-declare -r unbold=$'\033[21m'
+declare -r unbold=$'\033[22m'
 declare -r undim=$'\033[22m'
 declare -r nounderline=$'\033[24m'
 declare -r unblink=$'\033[25m'
@@ -38,5 +38,5 @@ function Urllink (){
     TEXT=$2
 
     # Generate a clickable hyperlink
-    printf "\e]8;;%s\e\\%s\e]8;;\e\\" "$URL" "$TEXT${n}"
+    printf "\033]8;;%s\033\\%s\033]8;;\033\\" "$URL" "$TEXT${n}"
 }


### PR DESCRIPTION
`\033[22m` is the correct ANSI code to unset bold mode (and faint/dim mode); `\033[21m` disables bold mode in some terminals but enables double-underline in others (for reference: https://gist.github.com/fnky/458719343aabd01cfb17a3a4f7296797). I also changed `\e` to `\033` in the clickable hyperlink helper function because that's more widely compatible.