### PR TITLE
feat(ublue-brew): add update/upgrade services and timers

### DIFF
--- a/packages/ublue-brew/src/systemd/01-homebrew.preset
+++ b/packages/ublue-brew/src/systemd/01-homebrew.preset
@@ -1,1 +1,3 @@
 enable brew-setup.service
+enable brew-update.timer
+enable brew-upgrade.timer

--- a/packages/ublue-brew/src/systemd/brew-update.service
+++ b/packages/ublue-brew/src/systemd/brew-update.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Auto update brew for mutable brew installs
+After=local-fs.target
+After=network-online.target
+ConditionPathIsSymbolicLink=/home/linuxbrew/.linuxbrew/bin/brew
+
+[Service]
+# Override the user if different UID/User
+User=1000
+Type=oneshot
+Environment=HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar
+Environment=HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
+Environment=HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
+ExecStart=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew update"

--- a/packages/ublue-brew/src/systemd/brew-update.timer
+++ b/packages/ublue-brew/src/systemd/brew-update.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Timer for brew update for mutable brew
+Wants=network-online.target
+
+[Timer]
+OnBootSec=10min
+OnUnitInactiveSec=6h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/packages/ublue-brew/src/systemd/brew-upgrade.service
+++ b/packages/ublue-brew/src/systemd/brew-upgrade.service
@@ -14,4 +14,4 @@ Environment=HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
 ExecStart=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew upgrade"
 # Prevent Brew from overriding important system binaries like:
 # systemctl, loginctl, dbus-*
-ExecStartPost=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink systemd dbus || true"
+ExecStartPost=-/home/linuxbrew/.linuxbrew/bin/brew unlink systemd dbus

--- a/packages/ublue-brew/src/systemd/brew-upgrade.service
+++ b/packages/ublue-brew/src/systemd/brew-upgrade.service
@@ -14,4 +14,4 @@ Environment=HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
 ExecStart=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew upgrade"
 # Prevent Brew from overriding important system binaries like:
 # systemctl, loginctl, dbus-*
-ExecStartPost=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink systemd dbus"
+ExecStartPost=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink systemd dbus || true"

--- a/packages/ublue-brew/src/systemd/brew-upgrade.service
+++ b/packages/ublue-brew/src/systemd/brew-upgrade.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Upgrade Brew packages
+After=local-fs.target
+After=network-online.target
+ConditionPathIsSymbolicLink=/home/linuxbrew/.linuxbrew/bin/brew
+
+[Service]
+# Override the user if different UID/User
+User=1000
+Type=oneshot
+Environment=HOMEBREW_CELLAR=/home/linuxbrew/.linuxbrew/Cellar
+Environment=HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
+Environment=HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
+ExecStart=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew upgrade"
+# Prevent Brew from overriding important system binaries like:
+# systemctl, loginctl, dbus-*
+ExecStartPost=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink systemd dbus"

--- a/packages/ublue-brew/src/systemd/brew-upgrade.timer
+++ b/packages/ublue-brew/src/systemd/brew-upgrade.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Timer for brew upgrade for on image brew
+Wants=network-online.target
+
+[Timer]
+OnBootSec=30min
+OnUnitInactiveSec=8h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/packages/ublue-brew/ublue-brew.spec
+++ b/packages/ublue-brew/ublue-brew.spec
@@ -45,6 +45,10 @@ cp -rp src/tmpfiles.d %{buildroot}%{_prefix}/lib
 %{_datadir}/fish/vendor_conf.d/%{name}.fish
 %{_sysconfdir}/security/limits.d/*brew*.conf
 %{_unitdir}/brew-setup.service
+%{_unitdir}/brew-update.timer
+%{_unitdir}/brew-update.service
+%{_unitdir}/brew-upgrade.timer
+%{_unitdir}/brew-upgrade.service
 %{_prefix}/lib/systemd/system-preset/01-homebrew.preset
 %{_prefix}/lib/tmpfiles.d/*brew.conf
 


### PR DESCRIPTION
These services and timers are taken directly from Aurora, with the exception of adding the unlink logic from https://github.com/ublue-os/packages/issues/269#issuecomment-2728550758 to `brew-upgrade.service`.

Closes #269.