### PR TITLE
chore(kcm_ublue): bump version to 0.5.8

### DIFF
--- a/packages/kcm_ublue/kcm_ublue.spec
+++ b/packages/kcm_ublue/kcm_ublue.spec
@@ -1,4 +1,4 @@
-%global majmin_ver_kcm 0.5.7
+%global majmin_ver_kcm 0.5.8
 
 Name:           kcm_ublue
 Version:        %{majmin_ver_kcm}


### PR DESCRIPTION
## What's Changed
* fix: rework notify-send to not use systemd-run by @ledif in https://github.com/ledif/kcm_ublue/pull/17


**Full Changelog**: https://github.com/ledif/kcm_ublue/compare/v0.5.7...v0.5.8