### PR TITLE
revert: remove the safe-to-run tag

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -3,12 +3,10 @@ name: Build packages in CI
 on:
   merge_group:
   pull_request:
-    types: [labeled]
 
 jobs:
   changed_files:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'safe-to-run')
     name: Get changed files
     outputs:
       all_changed_files: ${{ steps.changed-package-files.outputs.all_changed_files }}


### PR DESCRIPTION
Its a good idea but its causing more trouble than not right now. We can maybe use this again at some point when we make sure this is more "standard" across all repos
