### PR TITLE
fix(ublue-brew): include missing timer units

### DIFF
--- a/packages/ublue-brew/ublue-brew.spec
+++ b/packages/ublue-brew/ublue-brew.spec
@@ -26,6 +26,7 @@ Homebrew integration for Universal Blue systems
 mkdir -p %{buildroot}{%{_unitdir},%{_prefix}/lib/systemd/system-preset,%{_sysconfdir}}
 install -Dpm0644 %{SOURCE1} %{buildroot}/%{_datadir}/homebrew.tar.zst
 install -Dpm0644 src/systemd/*.service %{buildroot}%{_unitdir}
+install -Dpm0644 src/systemd/*.timer %{buildroot}%{_unitdir}
 install -Dpm0644 src/systemd/*.preset %{buildroot}%{_prefix}/lib/systemd/system-preset
 install -Dm0644 ./src/vendor.fish %{buildroot}%{_datadir}/fish/vendor_conf.d/%{name}.fish
 cp -rp src/security %{buildroot}%{_sysconfdir}

--- a/packages/ublue-brew/ublue-brew.spec
+++ b/packages/ublue-brew/ublue-brew.spec
@@ -4,7 +4,7 @@
 
 Name:           ublue-brew
 Version:        0.1.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Homebrew integration for Universal Blue systems
 
 License:        Apache-2.0


### PR DESCRIPTION
The build is failing in copr because I forgot to include the `.timer` unit files in the `install` section:

```bash
RPM build errors:
error: File not found: /builddir/build/BUILD/ublue-brew-0.1.3-build/BUILDROOT/usr/lib/systemd/system/brew-update.timer
error: File not found: /builddir/build/BUILD/ublue-brew-0.1.3-build/BUILDROOT/usr/lib/systemd/system/brew-upgrade.timer
    File not found: /builddir/build/BUILD/ublue-brew-0.1.3-build/BUILDROOT/usr/lib/systemd/system/brew-update.timer
    File not found: /builddir/build/BUILD/ublue-brew-0.1.3-build/BUILDROOT/usr/lib/systemd/system/brew-upgrade.timer
```
> Source: https://download.copr.fedorainfracloud.org/results/ublue-os/packages/fedora-41-x86_64/08863563-ublue-brew/builder-live.log.gz

I wonder why the CI did not catch this.