### PR TITLE
fix(ublue-os-udev-rules): update via keyboard rules following upstream instructions

### DIFF
--- a/packages/ublue-os-udev-rules/src/udev-rules.d/92-viia.rules
+++ b/packages/ublue-os-udev-rules/src/udev-rules.d/92-viia.rules
@@ -1,1 +1,1 @@
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", MODE="0666", TAG+="uaccess", TAG+="udev-acl"
+KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{serial}=="*vial:f64c2b3c*", MODE="0660", GROUP="input", TAG+="uaccess", TAG+="udev-acl"

--- a/packages/ublue-os-udev-rules/ublue-os-udev-rules.spec
+++ b/packages/ublue-os-udev-rules/ublue-os-udev-rules.spec
@@ -7,7 +7,7 @@
 
 Name:           ublue-os-udev-rules
 Vendor:         ublue-os
-Version:        0.9
+Version:        0.91
 Release:        1%{?dist}
 Summary:        Additional udev files for device support
 
@@ -60,6 +60,9 @@ install -p -m0644 %{buildroot}%{_datadir}/%{VENDOR}/{%{sub_name},game-devices-ud
 
 
 %changelog
+* Tue Apr 8 2025 Tulip Blossom <tulilirockz@proton.me> - 0.91
+- Update VIA udev rules with upstream instructions (input group)
+
 * Tue Jun 25 2024 Fifty Dinar <srbaizoki4@tuta.io> - 0.10
 - Add Apple SuperDrive udev rule
 


### PR DESCRIPTION
I pretty much just copied the manual rules from <https://get.vial.today/manual/linux-udev.html> and set the default group to `input` instead of `users`
