### PR TITLE
chore: bump release field of aurofin

### DIFF
--- a/packages/aurora/aurora.spec
+++ b/packages/aurora/aurora.spec
@@ -3,7 +3,7 @@
 
 Name:           aurora
 Version:        0.1.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Aurora branding
 
 License:        CC-BY-CA

--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -3,7 +3,7 @@
 
 Name:           bluefin
 Version:        0.2.3
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Bluefin branding
 
 License:        CC-BY-CA


### PR DESCRIPTION
Apparently I bumped the version wrong and the newer packages aren't being downloaded because they have lower or equal "NEVRA"

Someone on the fedora copr matrix suggested this to me.