### PR TITLE
ci: remove container pinning on GHA from renovate config and use wolfi for ublue builder manifest action

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,6 +34,12 @@
   ],
   "packageRules": [
     {
+      "enabled": false,
+      "matchUpdateTypes": ["digest", "pinDigest", "pin"],
+      "matchDepTypes": ["container"],
+      "matchFileNames": [".github/workflows/**.yaml", ".github/workflows/**.yml"],
+    },
+    {
       "matchPackageNames": ["rpm-ostree"],
       "extractVersion": "^(?<version>\\d+\\.\\d+)",
     }

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -142,7 +142,7 @@ jobs:
       - generate_matrix
       - build_push
     container:
-      image: quay.io/fedora/fedora:41@sha256:1d9dd61c8775a28efe7bfbb42b3a0585da1a576afdb244ae26f98c00a502adae
+      image:  cgr.dev/chainguard/wolfi-base:latest
       options: --privileged --security-opt seccomp=unconfined
     permissions:
       contents: read
@@ -154,12 +154,19 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          dnf install -y \
+          apk add \
             jq \
-            git
-
-          dnf copr enable -y rhcontainerbot/podman-next
-          dnf install -y podman
+            git \
+            podman \
+            uutils \
+            bash \
+            conmon \
+            crun \
+            netavark \
+            fuse-overlayfs
+          ln -sf /bin/bash /bin/sh
+          mkdir -p /etc/containers
+          echo '{"default":[{"type":"insecureAcceptAnything"}]}' | jq . > /etc/containers/policy.json
 
       - name: Exit on failure
         env:


### PR DESCRIPTION
This unblocks ublue-builder's latest builds since it fixes the container, it also changes the container to wolfi-base (just straight up better than using fedora in this case). And I also removed the container pinning on the github actions because we will always run into dumb stuff like this, some container getting pinned then the action breaking for a month or something