### PR TITLE
fix(ublue-builder): make it so build logs get printed after mock failure

### DIFF
--- a/ublue-builder/mock-wrapper
+++ b/ublue-builder/mock-wrapper
@@ -47,6 +47,7 @@ rpkg --path "${SPEC_PATH}" srpm --outdir "${OUTDIR}"
 ls -lah "${OUTDIR}"
 group_end
 
+set +euo pipefail
 group_start "Build RPM with mock"
 if [ "$BUILDER_NO_INCLUDE_SRPM" != "1" ] ; then
   mock --isolation=simple "$OUTDIR"/*.src.rpm "$@"


### PR DESCRIPTION
We werent getting any logs because when mock dies it just exited everything :P
