### PR TITLE
fix(staging,logomenu): make sure logos are getting included on logomenu's package

### DIFF
--- a/staging/gnome-shell-extension-logo-menu/gnome-shell-extension-logo-menu.spec
+++ b/staging/gnome-shell-extension-logo-menu/gnome-shell-extension-logo-menu.spec
@@ -6,7 +6,7 @@
 
 Name:          gnome-shell-extension-logo-menu
 Version:       0.0.0
-Release:       1%{gitrel}%{?dist}
+Release:       2%{gitrel}%{?dist}
 Summary:       Quick access menu for the GNOME panel
 
 Group:         User Interface/Desktops
@@ -34,15 +34,15 @@ Quick access menu for the GNOME panel with options that help ease the workflow f
 %build
 
 %install
-install -Dpm0644 -t schemas %{SOURCE1}
-install -Dpm0644 -t Resouces %{SOURCE2}
-install -Dpm0644 -t Resouces %{SOURCE3}
 install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/ *.js
 install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/ *.json
 install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/ *.css
 install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/schemas/ schemas/*.xml
+install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/schemas/ %{SOURCE1}
 install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/po/ po/*.po
 install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/Resources/ Resources/*.svg
+install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/Resouces %{SOURCE2}
+install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/Resouces %{SOURCE3}
 install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/PrefsLib/ PrefsLib/*.js
 glib-compile-schemas %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/schemas/
 

--- a/staging/gnome-shell-extension-logo-menu/gnome-shell-extension-logo-menu.spec
+++ b/staging/gnome-shell-extension-logo-menu/gnome-shell-extension-logo-menu.spec
@@ -12,10 +12,12 @@ Summary:       Quick access menu for the GNOME panel
 Group:         User Interface/Desktops
 License:       GPLv2
 URL:           https://github.com/Aryan20/Logomenu
+
 Source0:       %{url}/archive/%{commit}.tar.gz
 Source1:       org.gnome.shell.extensions.logo-menu.gschema.xml
 Source2:       ampere-logo-symbolic.svg
 Source3:       framework-logo-symbolic.svg
+
 BuildArch:     noarch
 
 Patch0:        extension-boxbuddy.patch
@@ -41,8 +43,8 @@ install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/schem
 install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/schemas/ %{SOURCE1}
 install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/po/ po/*.po
 install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/Resources/ Resources/*.svg
-install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/Resouces %{SOURCE2}
-install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/Resouces %{SOURCE3}
+install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/Resources %{SOURCE2}
+install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/Resources %{SOURCE3}
 install -Dpm0644 -t %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/PrefsLib/ PrefsLib/*.js
 glib-compile-schemas %{buildroot}%{_datadir}/gnome-shell/extensions/%{uuid}/schemas/
 


### PR DESCRIPTION

Fixes: https://github.com/ublue-os/bluefin/issues/2348
The logo install was being expanded before installing the framework and ampere logos so it didnt show up on the package