### PR TITLE
feat: add readymade to favorites

### DIFF
--- a/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -1,7 +1,7 @@
 #-------------- DESKTOP MODIFICATIONS --------------#
 
 [org.gnome.shell]
-favorite-apps = ['org.mozilla.firefox.desktop', 'org.mozilla.Thunderbird.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Rhythmbox3.desktop', 'org.libreoffice.LibreOffice.writer.desktop', 'org.gnome.Software.desktop', 'code.desktop', 'ubuntu.desktop', 'yelp.desktop']
+favorite-apps = ['com.fyralabs.Readymade.desktop', 'org.mozilla.firefox.desktop', 'org.mozilla.Thunderbird.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Software.desktop', 'code.desktop']
 enabled-extensions = ['appindicatorsupport@rgcjonas.gmail.com', 'dash-to-dock@micxgx.gmail.com', 'blur-my-shell@aunetx', 'gsconnect@andyholmes.github.io', 'logomenu@aryan_k', 'tailscale@joaophi.github.com', 'search-light@icedman.github.com']
 
 [org.gnome.desktop.background]


### PR DESCRIPTION
This will only show up on the live ISO. Also cleans up old vestigial stuff.

Just to confirm, the readymade binary won't be on the final installed system right? We wouldn't want this showing up on existing systems. 