### PR TITLE
fix: unlink python in brew-upgrade.service

### DIFF
--- a/packages/ublue-brew/src/systemd/brew-upgrade.service
+++ b/packages/ublue-brew/src/systemd/brew-upgrade.service
@@ -13,5 +13,7 @@ Environment=HOMEBREW_PREFIX=/home/linuxbrew/.linuxbrew
 Environment=HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
 ExecStart=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew upgrade"
 # Prevent Brew from overriding important system binaries like:
-# systemctl, loginctl, dbus-*
-ExecStartPost=-/home/linuxbrew/.linuxbrew/bin/brew unlink systemd dbus python
+# systemctl, loginctl, dbus-*, python*
+ExecStartPost=-/home/linuxbrew/.linuxbrew/bin/brew unlink systemd
+ExecStartPost=-/home/linuxbrew/.linuxbrew/bin/brew unlink dbus
+ExecStartPost=-/home/linuxbrew/.linuxbrew/bin/brew unlink python

--- a/packages/ublue-brew/src/systemd/brew-upgrade.service
+++ b/packages/ublue-brew/src/systemd/brew-upgrade.service
@@ -14,4 +14,4 @@ Environment=HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
 ExecStart=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew upgrade"
 # Prevent Brew from overriding important system binaries like:
 # systemctl, loginctl, dbus-*
-ExecStartPost=-/home/linuxbrew/.linuxbrew/bin/brew unlink systemd dbus
+ExecStartPost=-/home/linuxbrew/.linuxbrew/bin/brew unlink systemd dbus python


### PR DESCRIPTION
User report from Discord that Nautilus wouldn't start because brew's Python was in their PATH.

https://discord.com/channels/1072614816579063828/1087140903031943178/1362410617780178994
```
~> which python3
/home/linuxbrew/.linuxbrew/bin/python3
~> python3 -c 'import gi; print(gi)'
<module 'gi' (namespace) from ['/home/linuxbrew/.linuxbrew/Cellar/python@3.13/3.13.3/lib/python3.13/site-packages/gi']>
```