### PR TITLE
Revert "fix(ublue-os-udev-rules): update source of the Realtek 50-usb-realtek-net.rules file (#374)

### DIFF
--- a/packages/ublue-os-udev-rules/src/udev-rules.d/50-usb-realtek-net.rules
+++ b/packages/ublue-os-udev-rules/src/udev-rules.d/50-usb-realtek-net.rules
@@ -1,0 +1,46 @@
+# This is used to change the default configuration of Realtek USB ethernet adapters
+
+ACTION!="add", GOTO="usb_realtek_net_end"
+SUBSYSTEM!="usb", GOTO="usb_realtek_net_end"
+ENV{DEVTYPE}!="usb_device", GOTO="usb_realtek_net_end"
+
+# Modify this to change the default value
+ENV{REALTEK_MODE1}="1"
+ENV{REALTEK_MODE2}="3"
+
+# Realtek
+ATTR{idVendor}=="0bda", ATTR{idProduct}=="815[2,3,5,6]", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="0bda", ATTR{idProduct}=="8053", ATTR{bcdDevice}=="e???", ATTR{bConfigurationValue}!="$env{REALTEK_MODE2}", ATTR{bConfigurationValue}="$env{REALTEK_MODE2}"
+
+# Samsung
+ATTR{idVendor}=="04e8", ATTR{idProduct}=="a101", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+
+# Lenovo
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="304f", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="3052", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="3054", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="3057", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="3062", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="3069", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="3082", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="3098", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="7205", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="720a", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="720b", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="720c", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="7214", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="721e", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="8153", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="a359", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+ATTR{idVendor}=="17ef", ATTR{idProduct}=="a387", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+
+# TP-LINK
+ATTR{idVendor}=="2357", ATTR{idProduct}=="0601", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+
+# Nvidia
+ATTR{idVendor}=="0955", ATTR{idProduct}=="09ff", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+
+# LINKSYS
+ATTR{idVendor}=="13b1", ATTR{idProduct}=="0041", ATTR{bConfigurationValue}!="$env{REALTEK_MODE1}", ATTR{bConfigurationValue}="$env{REALTEK_MODE1}"
+
+LABEL="usb_realtek_net_end"

--- a/packages/ublue-os-udev-rules/ublue-os-udev-rules.spec
+++ b/packages/ublue-os-udev-rules/ublue-os-udev-rules.spec
@@ -4,12 +4,10 @@
 %define sunshine_release v2025.122.141614
 # renovate: datasource=github-releases depName=FrameworkComputer/inputmodule-rs
 %define framework_release v0.2.0
-# renovate: datasource=github-releases depName=bb-qq/r8152
-%define rtl8152_release 2.19.2-2
 
 Name:           ublue-os-udev-rules
 Vendor:         ublue-os
-Version:        0.11
+Version:        0.9
 Release:        1%{?dist}
 Summary:        Additional udev files for device support
 
@@ -24,7 +22,6 @@ Source0:        {{{ git_dir_pack }}}
 Source1:        https://codeberg.org/fabiscafe/game-devices-udev/archive/%{game_devices_release}.tar.gz
 Source2:        https://raw.githubusercontent.com/LizardByte/Sunshine/refs/tags/%{sunshine_release}/src_assets/linux/misc/60-sunshine.rules
 Source3:        https://raw.githubusercontent.com/FrameworkComputer/inputmodule-rs/refs/tags/%{framework_release}/release/50-framework-inputmodule.rules
-Source4:        https://raw.githubusercontent.com/bb-qq/r8152/refs/tags/%{rtl8152_release}/50-usb-realtek-net.rules
 
 %global sub_name %{lua:t=string.gsub(rpm.expand("%{NAME}"), "^ublue%-os%-", ""); print(t)}
 
@@ -48,7 +45,6 @@ tar xzf %{SOURCE1} -C %{buildroot}%{_datadir}/%{VENDOR}/game-devices-udev --stri
 # add other remote-sourced rules
 install -m0644 %{SOURCE2} %{buildroot}%{_datadir}/%{VENDOR}/%{sub_name}/60-sunshine-ublue.rules
 install -m0644 %{SOURCE3} %{buildroot}%{_datadir}/%{VENDOR}/%{sub_name}/50-framework-inputmodule.rules
-install -m0644 %{SOURCE4} %{buildroot}%{_datadir}/%{VENDOR}/%{sub_name}/50-usb-realtek-net.rules
 
 mkdir -p -m0755 %{buildroot}%{_exec_prefix}/lib/udev/rules.d
 install -p -m0644 %{buildroot}%{_datadir}/%{VENDOR}/{%{sub_name},game-devices-udev}/*.rules %{buildroot}%{_exec_prefix}/lib/udev/rules.d/
@@ -64,9 +60,6 @@ install -p -m0644 %{buildroot}%{_datadir}/%{VENDOR}/{%{sub_name},game-devices-ud
 
 
 %changelog
-* Sun Apr 20 2025 Jason Berry <jason@skyblaster.ca> - 0.11
-- Update usb-realtek-net rules
-
 * Tue Jun 25 2024 Fifty Dinar <srbaizoki4@tuta.io> - 0.10
 - Add Apple SuperDrive udev rule
 


### PR DESCRIPTION
This reverts commit fc2583bea4d5c45f455f97d51bf464d2f9e8d989.

Requested by original PR contributor here:
https://github.com/ublue-os/packages/pull/374#issuecomment-2819057311