### PR TITLE
fix(aurora): Installation error when using kubernetes brewfile

### DIFF
--- a/packages/aurora/aurora.spec
+++ b/packages/aurora/aurora.spec
@@ -2,7 +2,7 @@
 %global vendor aurora
 
 Name:           aurora
-Version:        0.1.5
+Version:        0.1.6
 Release:        1%{?dist}
 Summary:        Aurora branding
 
@@ -121,7 +121,7 @@ Plymouth logo customization for Aurora
 
 
 %package schemas
-Version:        0.1.0
+Version:        0.1.1
 Summary:        KDE Schemas for Aurora
 
 %description schemas

--- a/packages/aurora/schemas/usr/share/ublue-os/homebrew/kubernetes.Brewfile
+++ b/packages/aurora/schemas/usr/share/ublue-os/homebrew/kubernetes.Brewfile
@@ -1,6 +1,7 @@
+tap buildpacks/tap
 brew "cdk8s"
 brew "dagger"
 brew "kubectl"
 brew "k9s"
 brew "kubectx"
-brew tap buildpacks/tap
+brew "pack"

--- a/packages/aurora/schemas/usr/share/ublue-os/homebrew/kubernetes.Brewfile
+++ b/packages/aurora/schemas/usr/share/ublue-os/homebrew/kubernetes.Brewfile
@@ -3,4 +3,4 @@ brew "dagger"
 brew "kubectl"
 brew "k9s"
 brew "kubectx"
-brew "pack"
+brew tap buildpacks/tap


### PR DESCRIPTION
This should fix the install-k8s-devtools brewfile when using the ujust to install these tools.