### PR TITLE
ublue-fastfetch: remove alias for hyfetch

### DIFF
--- a/packages/ublue-fastfetch/src/vendor.fish
+++ b/packages/ublue-fastfetch/src/vendor.fish
@@ -1,4 +1,3 @@
 alias neofetch='/usr/libexec/ublue-fastfetch'
 alias neowofetch='/usr/libexec/ublue-fastfetch'
-alias hyfetch='/usr/libexec/ublue-fastfetch'
 alias fastfetch='/usr/libexec/ublue-fastfetch'

--- a/packages/ublue-fastfetch/src/vendor.sh
+++ b/packages/ublue-fastfetch/src/vendor.sh
@@ -1,4 +1,3 @@
 alias neofetch='/usr/libexec/ublue-fastfetch'
 alias neowofetch='/usr/libexec/ublue-fastfetch'
-alias hyfetch='/usr/libexec/ublue-fastfetch'
 alias fastfetch='/usr/libexec/ublue-fastfetch'


### PR DESCRIPTION
The alias is unnecessary for people who don't know what hyfetch is while getting in the way of people who do know what hyfetch is and wish to use it.