### PR TITLE
fix(ublue-builder): make failures be recognized as failures on the mock wrapper

### DIFF
--- a/ublue-builder/mock-wrapper
+++ b/ublue-builder/mock-wrapper
@@ -49,15 +49,21 @@ group_end
 
 set +euo pipefail
 group_start "Build RPM with mock"
+MOCK_EXIT=0
 if [ "$BUILDER_NO_INCLUDE_SRPM" != "1" ] ; then
   mock --isolation=simple "$OUTDIR"/*.src.rpm "$@"
+  MOCK_EXIT=$?
 else
   mock --isolation=simple "$@"
+  MOCK_EXIT=$?
 fi
 group_end
+set -euo pipefail
 
 while IFS= read -r -d $'\0' log_file; do
   group_start "Build logs: ${log_file}"
   cat $log_file
   group_end
 done < <(find /var/lib/mock/*/result -type f -iname '*.log' -print0)
+
+exit $MOCK_EXIT


### PR DESCRIPTION
This just makes it so if the build fails it actually fails instead of saying its ok
