### PR TITLE
feat(logomenu): use distroshelf instead of boxbuddy for containers entry

### DIFF
--- a/staging/gnome-shell-extension-logo-menu/extension-boxbuddy.patch
+++ b/staging/gnome-shell-extension-logo-menu/extension-boxbuddy.patch
@@ -66,7 +66,7 @@ index a371565..240edaa 100644
      }
  
 +    _openBoxBuddy() {
-+        Util.trySpawnCommandLine('flatpak run io.github.dvlv.boxbuddyrs');
++        Util.trySpawnCommandLine('flatpak run com.ranfdev.DistroShelf');
 +    }
 +
      _openSoftwareCenter() {

--- a/staging/gnome-shell-extension-logo-menu/gnome-shell-extension-logo-menu.spec
+++ b/staging/gnome-shell-extension-logo-menu/gnome-shell-extension-logo-menu.spec
@@ -1,12 +1,13 @@
 %global uuid logomenu@aryan_k
 
+# renovate: datasource=github-releases depName=Aryan20/Logomenu
 %global commit bbbc77836d1bb853f4bbaf683674c3bbae19cf66
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global gitrel      .git%{shortcommit}
 
 Name:          gnome-shell-extension-logo-menu
 Version:       0.0.0
-Release:       2%{gitrel}%{?dist}
+Release:       3%{gitrel}%{?dist}
 Summary:       Quick access menu for the GNOME panel
 
 Group:         User Interface/Desktops


### PR DESCRIPTION
cc @castrojo 