### PR TITLE
refactor: set arch to noarch for most `ublue-*` packages

### DIFF
--- a/packages/aurora/aurora.spec
+++ b/packages/aurora/aurora.spec
@@ -2,14 +2,16 @@
 %global vendor aurora
 
 Name:           aurora
-Version:        0.1.8
+Version:        0.1.9
 Release:        1%{?dist}
 Summary:        Aurora branding
 
 License:        CC-BY-SA
 URL:            https://github.com/ublue-os/packages
-VCS:           {{{ git_dir_vcs }}}
-Source:        {{{ git_dir_pack }}}
+VCS:            {{{ git_dir_vcs }}}
+Source:         {{{ git_dir_pack }}}
+
+BuildArch:      noarch
 
 %description
 Branding for Aurora-related projects

--- a/packages/bluefin-readymade-config/bluefin-readymade-config.spec
+++ b/packages/bluefin-readymade-config/bluefin-readymade-config.spec
@@ -12,7 +12,8 @@ VCS:            {{{ git_dir_vcs }}}
 Source0:        {{{ git_dir_pack }}}
 Source1:        https://github.com/FyraLabs/readymade/archive/refs/tags/v0.12.2.tar.gz
 
-BuildRequires: glib2-devel
+BuildRequires:  glib2-devel
+BuildArch:      noarch
 
 %description
 Branding for Bluefin's Readymade config

--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -2,14 +2,16 @@
 %global vendor bluefin
 
 Name:           bluefin
-Version:        0.2.8
+Version:        0.2.9
 Release:        1%{?dist}
 Summary:        Bluefin branding
 
 License:        CC-BY-CA
 URL:            https://github.com/ublue-os/packages
-VCS:           {{{ git_dir_vcs }}}
-Source:        {{{ git_dir_pack }}}
+VCS:            {{{ git_dir_vcs }}}
+Source:         {{{ git_dir_pack }}}
+
+BuildArch:      noarch
 
 %description
 Branding for Bluefin-related projects

--- a/packages/ublue-bling/ublue-bling.spec
+++ b/packages/ublue-bling/ublue-bling.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-bling
-Version:        0.1.5
+Version:        0.1.6
 Release:        1%{?dist}
 Summary:        Universal Blue Bling CLI setup scripts
 
@@ -11,6 +11,7 @@ VCS:            {{{ git_dir_vcs }}}
 Source:         {{{ git_dir_pack }}}
 
 Requires:       gum
+BuildArch:      noarch
 # FIXME: make ublue-builder be able to handle stuff like this
 # Requires:       ublue-os-just
 

--- a/packages/ublue-fastfetch/ublue-fastfetch.spec
+++ b/packages/ublue-fastfetch/ublue-fastfetch.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-fastfetch
-Version:        0.1.3
+Version:        0.1.4
 Release:        1%{?dist}
 Summary:        Fastfetch configuration for Universal Blue systems
 
@@ -11,6 +11,7 @@ VCS:            {{{ git_dir_vcs }}}
 Source:         {{{ git_dir_pack }}}
 
 Requires:       fastfetch
+BuildArch:      noarch
 
 %description
 Fastfetch configuration for Universal Blue systems
@@ -19,8 +20,8 @@ Fastfetch configuration for Universal Blue systems
 {{{ git_dir_setup_macro }}}
 
 %install
-install -Dm0755 ./src/%{name} %{buildroot}%{_libexecdir}/%{name}
-install -Dm0755 ./src/ublue-bling-fastfetch %{buildroot}%{_libexecdir}/ublue-bling-fastfetch
+install -Dm0755 -t %{buildroot}%{_libexecdir}/ ./src/%{name}
+install -Dm0755 -t %{buildroot}%{_libexecdir}/ ./src/ublue-bling-fastfetch
 install -Dm0755 ./src/vendor.sh %{buildroot}%{_sysconfdir}/profile.d/%{name}.sh
 install -Dm0755 ./src/vendor.fish %{buildroot}%{_datadir}/fish/vendor_conf.d/%{name}.fish
 

--- a/packages/ublue-motd/ublue-motd.spec
+++ b/packages/ublue-motd/ublue-motd.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-motd
-Version:        0.2.4
+Version:        0.2.5
 Release:        1%{?dist}
 Summary:        MOTD scripts for Universal Blue images
 
@@ -14,6 +14,8 @@ Requires:       glow
 Requires:       jq
 Requires:       curl
 
+BuildArch:      noarch
+
 %description
 MOTD and changelogs script for Universal Blue
 
@@ -21,10 +23,9 @@ MOTD and changelogs script for Universal Blue
 {{{ git_dir_setup_macro }}}
 
 %install
-install -dm0755 %{buildroot}%{_datadir}/ublue-os/motd/themes
-cp -rp ./src/themes/* %{buildroot}%{_datadir}/ublue-os/motd/themes
-install -Dm0755 ./src/%{name} %{buildroot}%{_libexecdir}/%{name}
-install -Dm0755 ./src/ublue-changelog %{buildroot}%{_libexecdir}/ublue-changelog
+install -Dm0644 -t %{buildroot}%{_datadir}/ublue-os/motd/themes/ ./src/themes/*.json
+install -Dm0755 -t %{buildroot}%{_libexecdir}/ ./src/%{name}
+install -Dm0755 -t %{buildroot}%{_libexecdir}/ ./src/ublue-changelog
 install -Dm0755 ./src/vendor.sh %{buildroot}%{_sysconfdir}/profile.d/%{name}.sh
 install -Dm0755 ./src/vendor.fish %{buildroot}%{_datadir}/fish/vendor_conf.d/%{name}.fish
 

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -11,7 +11,7 @@ Source:         {{{ git_dir_pack }}}
 BuildArch:      noarch
 Requires:       just
 Requires:       ublue-os-luks
-Recommends:       powerstat
+Recommends:     powerstat
 
 %global sub_name %{lua:t=string.gsub(rpm.expand("%{NAME}"), "^ublue%-os%-", ""); print(t)}
 

--- a/packages/ublue-rebase-helper/ublue-rebase-helper.spec
+++ b/packages/ublue-rebase-helper/ublue-rebase-helper.spec
@@ -1,5 +1,3 @@
-%global debug_package %{nil}
-
 Name:           ublue-rebase-helper
 Version:        0.1.0
 Release:        1%{?dist}
@@ -9,6 +7,8 @@ License:        Apache-2.0
 URL:            https://github.com/ublue-os/packages
 VCS:            {{{ git_dir_vcs }}}
 Source0:        {{{ git_dir_pack }}}
+
+BuildArch:      noarch
 
 %description
 Rebase helper script and develoepr edition script for Universal Blue images

--- a/packages/ublue-setup-services/ublue-setup-services.spec
+++ b/packages/ublue-setup-services/ublue-setup-services.spec
@@ -11,6 +11,7 @@ VCS:            {{{ git_dir_vcs }}}
 Source:         {{{ git_dir_pack }}}
 
 BuildRequires:  systemd-rpm-macros
+BuildArch:      noarch
 
 %description
 Universal Blue setup scripts


### PR DESCRIPTION

This is more of a preparation for new architectures, this just tags all the `ublue-*`
packages as "noarch", so they arent architecture dependant since they already arent
(they are all just scripts). Also refactors a bit of a few packages to have better `install` statements