### PR TITLE
fix(logomenu): open up local PDF document

### DIFF
--- a/staging/gnome-shell-extension-logo-menu/extension-boxbuddy.patch
+++ b/staging/gnome-shell-extension-logo-menu/extension-boxbuddy.patch
@@ -55,7 +55,7 @@ index a371565..240edaa 100644
      }
  
 +    _documentation() {
-+        Util.trySpawnCommandLine('xdg-open https://docs.projectbluefin.io/')
++        Util.trySpawnCommandLine('xdg-open /usr/share/doc/bluefin/bluefin.pdf')
 +    }
 +
      _overviewToggle() {

--- a/staging/gnome-shell-extension-logo-menu/gnome-shell-extension-logo-menu.spec
+++ b/staging/gnome-shell-extension-logo-menu/gnome-shell-extension-logo-menu.spec
@@ -6,7 +6,7 @@
 
 Name:          gnome-shell-extension-logo-menu
 Version:       0.0.0
-Release:       2%{gitrel}%{?dist}
+Release:       3%{gitrel}%{?dist}
 Summary:       Quick access menu for the GNOME panel
 
 Group:         User Interface/Desktops


### PR DESCRIPTION

This will just open up the local document on the Logomenu extension for the bluefin build :)