### PR TITLE
chore: make Papers flatpak default for pdf

### DIFF
--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -2,7 +2,7 @@
 %global vendor bluefin
 
 Name:           bluefin
-Version:        0.2.9
+Version:        0.3.0
 Release:        1%{?dist}
 Summary:        Bluefin branding
 

--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -35,6 +35,7 @@ install -Dpm0644 -t %{buildroot}%{_datadir}/pixmaps/faces/bluefin/ faces/*
 install -Dpm0644 -t %{buildroot}%{_datadir}/ublue-os/ fastfetch/fastfetch.jsonc
 install -Dpm0644 -t %{buildroot}%{_datadir}/plymouth/themes/spinner/ plymouth/themes/spinner/*.png
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.config/toolbox/ schemas%{_sysconfdir}/skel/.config/toolbox/*
+install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.config/ schemas%{_sysconfdir}/skel/.config/mimeapps.list
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/profile.d/ schemas%{_sysconfdir}/profile.d/*.sh
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.local/share/flatpak/overrides/ schemas%{_sysconfdir}/skel/.local/share/flatpak/overrides/*
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.local/share/org.gnome.Ptyxis/palettes/ schemas%{_sysconfdir}/skel/.local/share/org.gnome.Ptyxis/palettes/*

--- a/packages/bluefin/schemas/etc/skel/.config/mimeapps.list
+++ b/packages/bluefin/schemas/etc/skel/.config/mimeapps.list
@@ -1,0 +1,2 @@
+[Default Applications]
+application/pdf=org.gnome.Papers


### PR DESCRIPTION
This PR makes the Papers Flatpak the default pdf viewer.

Fixes #428