### PR TITLE
fix(bluefin): move mimeapps.list to /etc/xdg

### DIFF
--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -35,7 +35,7 @@ install -Dpm0644 -t %{buildroot}%{_datadir}/pixmaps/faces/bluefin/ faces/*
 install -Dpm0644 -t %{buildroot}%{_datadir}/ublue-os/ fastfetch/fastfetch.jsonc
 install -Dpm0644 -t %{buildroot}%{_datadir}/plymouth/themes/spinner/ plymouth/themes/spinner/*.png
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.config/toolbox/ schemas%{_sysconfdir}/skel/.config/toolbox/*
-install -Dpm0644 -t %{buildroot}%{_sysconfdir}/xdg schemas%{_sysconfdir}/xdg
+install -Dpm0644 -t %{buildroot}%{_sysconfdir}/xdg schemas%{_sysconfdir}/xdg/*
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/profile.d/ schemas%{_sysconfdir}/profile.d/*.sh
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.local/share/flatpak/overrides/ schemas%{_sysconfdir}/skel/.local/share/flatpak/overrides/*
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.local/share/org.gnome.Ptyxis/palettes/ schemas%{_sysconfdir}/skel/.local/share/org.gnome.Ptyxis/palettes/*

--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -2,7 +2,7 @@
 %global vendor bluefin
 
 Name:           bluefin
-Version:        0.3.0
+Version:        0.3.1
 Release:        1%{?dist}
 Summary:        Bluefin branding
 
@@ -35,7 +35,7 @@ install -Dpm0644 -t %{buildroot}%{_datadir}/pixmaps/faces/bluefin/ faces/*
 install -Dpm0644 -t %{buildroot}%{_datadir}/ublue-os/ fastfetch/fastfetch.jsonc
 install -Dpm0644 -t %{buildroot}%{_datadir}/plymouth/themes/spinner/ plymouth/themes/spinner/*.png
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.config/toolbox/ schemas%{_sysconfdir}/skel/.config/toolbox/*
-install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.config/ schemas%{_sysconfdir}/skel/.config/mimeapps.list
+install -Dpm0644 -t %{buildroot}%{_sysconfdir}/xdg schemas%{_sysconfdir}/xdg
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/profile.d/ schemas%{_sysconfdir}/profile.d/*.sh
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.local/share/flatpak/overrides/ schemas%{_sysconfdir}/skel/.local/share/flatpak/overrides/*
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.local/share/org.gnome.Ptyxis/palettes/ schemas%{_sysconfdir}/skel/.local/share/org.gnome.Ptyxis/palettes/*
@@ -119,6 +119,7 @@ Contains all of the DConf settings that Bluefin ships by default
 %{_sysconfdir}/gnome-initial-setup
 %{_sysconfdir}/geoclue
 %{_sysconfdir}/skel
+%{_sysconfdir}/xdg
 %{_datadir}/glib-2.0
 %{_datadir}/applications
 %{_datadir}/ublue-os/homebrew/*.Brewfile

--- a/packages/bluefin/schemas/etc/skel/.config/mimeapps.list
+++ b/packages/bluefin/schemas/etc/skel/.config/mimeapps.list
@@ -1,2 +1,0 @@
-[Default Applications]
-application/pdf=org.gnome.Papers

--- a/packages/bluefin/schemas/etc/xdg/mimeapps.list
+++ b/packages/bluefin/schemas/etc/xdg/mimeapps.list
@@ -1,0 +1,2 @@
+[Default Applications]
+application/pdf=org.gnome.Papers.desktop


### PR DESCRIPTION
Since the `mimeapps.list` was placed in `/etc/skel/.config`, it only applied to new users. If we want the default app to be set for all users, it should be in `/etc/xdg`.

This file doesn't exist in Bluefin currently so there's no risk of overwriting an upstream Fedora file.
```bash
❯ podman run ghcr.io/ublue-os/bluefin:stable ls /etc/xdg
QtProject
Xwayland-session.d
autostart
menus
qtchooser
systemd
user-dirs.conf
user-dirs.defaults
❯ podman run ghcr.io/ublue-os/bluefin:stable cat /etc/xdg/mimeapps.list
cat: /etc/xdg/mimeapps.list: No such file or directory
```