### PR TITLE
feat(ublue-builder): add handling for external coprs

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -106,6 +106,9 @@ jobs:
 
       - name: Build ${{ matrix.spec }}
         id: build_package
+        env:
+          CHROOT: ${{ matrix.chroot }}
+          SPEC_FILE: ${{ matrix.spec }}
         run: |
           set -x
           just=$(which just)
@@ -115,9 +118,12 @@ jobs:
           CONTAINERS_DIR=./containers
           SOURCES_DIR=.
           export CONTAINERS_DIR
-          if ! $just build ${{ matrix.spec }} -r ${{ matrix.chroot }}-$(arch) ; then
+          # FIXME: this is a quick and dirty workaround, please make this pretty
+          COPR_NAMESPACE="$(basename $(dirname $(dirname $SPEC_FILE)))/$(basename $(dirname $SPEC_FILE))"
+          MOCK_COPRS="https://download.copr.fedorainfracloud.org/results/${COPR_NAMESPACE}/${CHROOT}-$(arch)"
+          if ! $just build ${SPEC_FILE} -r ${CHROOT}-$(arch) ; then
             echo "Retrying with a network connection"
-            $just build ${{ matrix.spec }} -r ${{ matrix.chroot }}-$(arch) --enable-network
+            $just build ${SPEC_FILE} -r ${CHROOT}-$(arch) --enable-network
           fi
           SKIPPED_ARCH=false
           if [ -e "$SOURCES_DIR/arch_skipped" ] ; then

--- a/Justfile
+++ b/Justfile
@@ -34,6 +34,7 @@ build $spec *MOCK_ARGS:
         -w /tmp/sources \
         --user "$(id -u):$(id -g)" \
         -e PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin,HOME=/tmp \
+        -e MOCK_COPRS=$MOCK_COPRS \
         --group-entry "mock:x:135:$(id -nu)" \
         $mock_image \
         $spec {{ MOCK_ARGS }}

--- a/ublue-builder/mock-wrapper
+++ b/ublue-builder/mock-wrapper
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# MOCK_COPRS exists as a comma-separated list of repos that will be enabled on mock
 BUILDER_NO_INCLUDE_SRPM=${BUILDER_NO_INCLUDE_SRPM:-0}
 SPEC_FILE=$1
 shift
@@ -50,11 +51,28 @@ group_end
 set +euo pipefail
 group_start "Build RPM with mock"
 MOCK_EXIT=0
+
+COPRS_RAW=()
+IFS=',' read -r -a COPRS_RAW <<< "${MOCK_COPRS}"
+COPRS=()
+
+for COPR in "${COPRS_RAW[@]}" ; do
+  COPRS+=("-a")
+  COPRS+=("${COPR}")
+done
+
 if [ "$BUILDER_NO_INCLUDE_SRPM" != "1" ] ; then
-  mock --isolation=simple "$OUTDIR"/*.src.rpm "$@"
+  mock \
+    --isolation=simple \
+    "$OUTDIR"/*.src.rpm \
+    "${COPRS[@]}"
+    "$@"
   MOCK_EXIT=$?
 else
-  mock --isolation=simple "$@"
+  mock \
+    --isolation=simple \
+    "${COPRS}" \
+    "$@"
   MOCK_EXIT=$?
 fi
 group_end


### PR DESCRIPTION
This makes it so `MOCK_REPOS` is a comma-separated list of repos that mock can use on ublue-builder, that way we finally have COPR support! Also adds some handling on the github actions part too

Tested it a bit, doesnt break when there are no COPRs, and makes it so everything works when there are COPRs. The only caveat is the weird handling that you need to do for the COPRs