### PR TITLE
fix: add CSS for bluefin anaconda branding

### DIFF
--- a/bluefin/fedora-logos/fedora-logos.spec
+++ b/bluefin/fedora-logos/fedora-logos.spec
@@ -3,7 +3,7 @@
 
 Name:           fedora-logos
 Version:        100.0.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Bluefin branding
 
 License:        CC-BY-CA

--- a/bluefin/fedora-logos/src/anaconda/fedora.css
+++ b/bluefin/fedora-logos/src/anaconda/fedora.css
@@ -1,0 +1,37 @@
+/* Anaconda gtk style overrides for Fedora */
+
+/* vendor-specific colors */
+@define-color fedora #51a2da;
+
+/* logo and sidebar classes */
+
+/* The sidebar consists of three parts: a background, a logo, and a product logo,
+ * rendered in that order. The product logo is empty by default and is intended
+ * to be overridden by a stylesheet in product.img.
+ */
+.logo-sidebar {
+    background-image: url("/usr/share/anaconda/pixmaps/sidebar-bg.png");
+    background-color: @fedora;
+    background-repeat: no-repeat;
+}
+
+/* Add a logo to the sidebar */
+.logo {
+    background-image: url("/usr/share/anaconda/pixmaps/sidebar-logo.png");
+    background-position: 50% 20px;
+    background-repeat: no-repeat;
+    background-color: transparent;
+}
+
+/* This is a placeholder to be filled by a product-specific logo. */
+.product-logo {
+    background-image: none;
+    background-color: transparent;
+}
+
+AnacondaSpokeWindow #nav-box {
+    background-color: @fedora;
+    background-image: url("/usr/share/anaconda/pixmaps/topbar-bg.png");
+    background-repeat: repeat;
+    color: white;
+}


### PR DESCRIPTION
We may have missed the CSS for fedora-logos package to find the update images.

This uses a CSS file from Aurora as is is known to work for their ISO and seems to map to our use case and images here, too. https://github.com/ublue-os/bluefin/blob/3bbcb7b98df817a5ebb4de4ee18d06a07289b826/spec_files/aurora/fedora-logos/fedora.css