### PR TITLE
feat: Use the new Adwaita font instead of Inter

### DIFF
--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -2,7 +2,7 @@
 %global vendor bluefin
 
 Name:           bluefin
-Version:        0.3.20
+Version:        0.3.21
 Release:        1%{?dist}
 Summary:        Bluefin branding
 

--- a/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -15,8 +15,8 @@ secondary-color='FFFFFF'
 enable-hot-corners=false
 clock-show-weekday=true
 font-antialiasing="rgba"
-font-name="Inter 12"
-document-font-name="Inter 12"
+font-name="Adwaita Sans 12"
+document-font-name="Adwaita Sans 12"
 monospace-font-name="JetBrains Mono 16"
 accent-color="slate"
 

--- a/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -27,7 +27,7 @@ theme-name="freedesktop"
 [org.gnome.desktop.wm.preferences]
 button-layout=":minimize,maximize,close"
 num-workspaces=4
-titlebar-font="Inter Bold 12"
+titlebar-font="Adwaita Sans Bold 12 @wght=700"
 
 [org.gnome.desktop.wm.keybindings]
 show-desktop=['<Super>d']


### PR DESCRIPTION
Gnome F48 now uses `Adwaita Sans` font as the default, this follows upstream.

Before merging, this requires installing either `adwaita-fonts` or only `adwaita-sans-fonts` in the bluefin repo. This is because it's bundled by default with F42 but we also need to take into account F41.

See https://blogs.gnome.org/monster/introducing-adwaita-fonts/