### PR TITLE
 fix(fastfetch): hide read-only mounts to not show composefs overlay 

### DIFF
--- a/packages/aurora/aurora.spec
+++ b/packages/aurora/aurora.spec
@@ -2,7 +2,7 @@
 %global vendor aurora
 
 Name:           aurora
-Version:        0.1.9
+Version:        0.2.0
 Release:        1%{?dist}
 Summary:        Aurora branding
 

--- a/packages/aurora/fastfetch/fastfetch.jsonc
+++ b/packages/aurora/fastfetch/fastfetch.jsonc
@@ -71,7 +71,8 @@
     },
     {
       "type": "disk",
-      "key": ""
+      "key": "",
+      "showReadOnly": true
     },
     {
       "type": "display",

--- a/packages/aurora/fastfetch/fastfetch.jsonc
+++ b/packages/aurora/fastfetch/fastfetch.jsonc
@@ -72,7 +72,7 @@
     {
       "type": "disk",
       "key": "",
-      "showReadOnly": true
+      "showReadOnly": false
     },
     {
       "type": "display",

--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -35,7 +35,7 @@ install -Dpm0644 -t %{buildroot}%{_datadir}/pixmaps/faces/bluefin/ faces/*
 install -Dpm0644 -t %{buildroot}%{_datadir}/ublue-os/ fastfetch/fastfetch.jsonc
 install -Dpm0644 -t %{buildroot}%{_datadir}/plymouth/themes/spinner/ plymouth/themes/spinner/*.png
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.config/toolbox/ schemas%{_sysconfdir}/skel/.config/toolbox/*
-install -Dpm0644 -t %{buildroot}%{_sysconfdir}/xdg schemas%{_sysconfdir}/xdg
+install -Dpm0644 -t %{buildroot}%{_sysconfdir}/xdg schemas%{_sysconfdir}/xdg/*
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/profile.d/ schemas%{_sysconfdir}/profile.d/*.sh
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.local/share/flatpak/overrides/ schemas%{_sysconfdir}/skel/.local/share/flatpak/overrides/*
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.local/share/org.gnome.Ptyxis/palettes/ schemas%{_sysconfdir}/skel/.local/share/org.gnome.Ptyxis/palettes/*

--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -35,7 +35,7 @@ install -Dpm0644 -t %{buildroot}%{_datadir}/pixmaps/faces/bluefin/ faces/*
 install -Dpm0644 -t %{buildroot}%{_datadir}/ublue-os/ fastfetch/fastfetch.jsonc
 install -Dpm0644 -t %{buildroot}%{_datadir}/plymouth/themes/spinner/ plymouth/themes/spinner/*.png
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.config/toolbox/ schemas%{_sysconfdir}/skel/.config/toolbox/*
-install -Dpm0644 -t %{buildroot}%{_sysconfdir}/xdg schemas%{_sysconfdir}/xdg/*
+install -Dpm0644 -t %{buildroot}%{_sysconfdir}/xdg schemas%{_sysconfdir}/xdg
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/profile.d/ schemas%{_sysconfdir}/profile.d/*.sh
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.local/share/flatpak/overrides/ schemas%{_sysconfdir}/skel/.local/share/flatpak/overrides/*
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/skel/.local/share/org.gnome.Ptyxis/palettes/ schemas%{_sysconfdir}/skel/.local/share/org.gnome.Ptyxis/palettes/*

--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -2,7 +2,7 @@
 %global vendor bluefin
 
 Name:           bluefin
-Version:        0.3.1
+Version:        0.3.2
 Release:        1%{?dist}
 Summary:        Bluefin branding
 

--- a/packages/bluefin/fastfetch/fastfetch.jsonc
+++ b/packages/bluefin/fastfetch/fastfetch.jsonc
@@ -61,7 +61,8 @@
     },
     {
       "type": "disk",
-      "key": ""
+      "key": "",
+      "showReadOnly": true
     },
     {
       "type": "display",

--- a/packages/bluefin/fastfetch/fastfetch.jsonc
+++ b/packages/bluefin/fastfetch/fastfetch.jsonc
@@ -62,7 +62,7 @@
     {
       "type": "disk",
       "key": "",
-      "showReadOnly": true
+      "showReadOnly": false
     },
     {
       "type": "display",


### PR DESCRIPTION
Need to wait on https://github.com/fastfetch-cli/fastfetch/pull/1762 to be merged first. Related to https://github.com/ublue-os/bazzite/pull/2648