### PR TITLE
fix(just): fix fish completion file directory

### DIFF
--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -1,6 +1,6 @@
 Name:           ublue-os-just
 Vendor:         ublue-os
-Version:        0.44
+Version:        0.45
 Release:        1%{?dist}
 Summary:        ublue-os just integration
 License:        Apache-2.0

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -80,10 +80,13 @@ just --completions zsh | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/zsh/si
 chmod 644 %{_datadir}/zsh/site-functions/_ujust
 
 # Generate ujust fish completion
-just --completions fish | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/fish/completions/ujust.fish
-chmod 644 %{_datadir}/fish/completions/ujust.fish
+just --completions fish | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/fish/vendor_completions.d/ujust.fish
+chmod 644 %{_datadir}/fish/vendor_completions.d/ujust.fish
 
 %changelog
+* Wed May 21 2025 coxde <63153334+coxde@users.noreply.github.com> - 0.45
+- Fix fish completion directory
+
 * Mon May 12 2025 coxde <63153334+coxde@users.noreply.github.com> - 0.44
 - Add fish ujust completion
 


### PR DESCRIPTION
Close #518

This should be the easiest way: put `ujust.fish` in `/usr/share/fish/vendor_completions.d/`, which already exists in the atomic/main image, so no extra fish deps or mkdir hack.

https://github.com/fish-shell/fish-shell/commit/5157ac30faf8fde5e9ea84977fdf430e01b71f96