### PR TITLE
fix: generate ujust shell completions on build time

### DIFF
--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -90,6 +90,9 @@ just --completions fish | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{fis
 %{fish_completions_dir}/ujust.fish
 
 %changelog
+* Thu May 22 2025 renner0e <Renner03@protonmail.com> - 0.46
+- Generate ujust shell completions at build time
+
 * Wed May 21 2025 coxde <63153334+coxde@users.noreply.github.com> - 0.45
 - Fix fish completion directory
 

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -57,6 +57,18 @@ install -Dpm0644 ./src/etc-distrobox/* %{buildroot}/%{_sysconfdir}/distrobox/
 install -d -m0755 %{buildroot}/%{_sysconfdir}/toolbox
 install -Dpm0644 ./src/etc-toolbox/* %{buildroot}/%{_sysconfdir}/toolbox/
 
+
+mkdir -p %{buildroot}%{bash_completions_dir} %{buildroot}%{zsh_completions_dir} %{buildroot}%{fish_completions_dir}
+
+# Generate ujust bash completion
+just --completions bash | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{bash_completions_dir}/ujust
+
+# Generate ujust zsh completion
+just --completions zsh | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{zsh_completions_dir}/_ujust
+
+# Generate ujust fish completion
+just --completions fish | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{fish_completions_dir}/ujust.fish
+
 %files
 %{_sysconfdir}/profile.d/user-motd.sh
 %{_sysconfdir}/profile.d/brew.sh
@@ -69,19 +81,9 @@ install -Dpm0644 ./src/etc-toolbox/* %{buildroot}/%{_sysconfdir}/toolbox/
 %{_exec_prefix}/lib/ujust/lib*.sh
 %{_sysconfdir}/distrobox/*.ini
 %{_sysconfdir}/toolbox/*.ini
-
-%post
-# Generate ujust bash completion
-just --completions bash | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/bash-completion/completions/ujust
-chmod 644 %{_datadir}/bash-completion/completions/ujust
-
-# Generate ujust zsh completion
-just --completions zsh | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/zsh/site-functions/_ujust
-chmod 644 %{_datadir}/zsh/site-functions/_ujust
-
-# Generate ujust fish completion
-just --completions fish | sed -E 's/([\(_" ])just/\1ujust/g' > %{_datadir}/fish/vendor_completions.d/ujust.fish
-chmod 644 %{_datadir}/fish/vendor_completions.d/ujust.fish
+%{bash_completions_dir}/ujust
+%{zsh_completions_dir}/_ujust
+%{fish_completions_dir}/ujust.fish
 
 %changelog
 * Wed May 21 2025 coxde <63153334+coxde@users.noreply.github.com> - 0.45

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -1,6 +1,6 @@
 Name:           ublue-os-just
 Vendor:         ublue-os
-Version:        0.45
+Version:        0.46
 Release:        1%{?dist}
 Summary:        ublue-os just integration
 License:        Apache-2.0

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -9,6 +9,10 @@ VCS:            {{{ git_dir_vcs }}}
 Source:         {{{ git_dir_pack }}}
 
 BuildArch:      noarch
+
+# Needed for generating shell completions
+BuildRequires: just
+
 Requires:       just
 Requires:       ublue-os-luks
 Recommends:     powerstat


### PR DESCRIPTION
this generates the ujust shell completion on build time instead of generating them on each client after every package installation in the `%post` step.

This has the benefit that the content is now actually tracked inside the rpm instead of essentially random files that are floating around the filesystem.

```
❯ rpm -qlp mock/fedora-42-x86_64/result/ublue-os-just-0.46-1.fc42.noarch.rpm
...
/usr/share/bash-completion/completions/ujust
/usr/share/fish/vendor_completions.d/ujust.fish
...
/usr/share/zsh/site-functions/_ujust

```

This also uses the proper respective rpm macros like `%{bash_completions_dir}`.