### PR TITLE
feat: Hide the overlay fs within fastfetch using the new hideFS param

### DIFF
--- a/packages/aurora/aurora.spec
+++ b/packages/aurora/aurora.spec
@@ -2,7 +2,7 @@
 %global vendor aurora
 
 Name:           aurora
-Version:        0.1.10
+Version:        0.1.11
 Release:        1%{?dist}
 Summary:        Aurora branding
 
@@ -101,7 +101,7 @@ Logos for CLI applications like Fastfetch
 
 %package fastfetch
 Summary:        Fastfetch configuration for Aurora
-Version:        0.1.3
+Version:        0.1.4
 License:        CC-BY-SA
 
 %description fastfetch

--- a/packages/aurora/fastfetch/fastfetch.jsonc
+++ b/packages/aurora/fastfetch/fastfetch.jsonc
@@ -71,7 +71,8 @@
     },
     {
       "type": "disk",
-      "key": ""
+      "key": "",
+      "hideFS": "overlay"
     },
     {
       "type": "display",

--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -2,7 +2,7 @@
 %global vendor bluefin
 
 Name:           bluefin
-Version:        0.3.5
+Version:        0.3.6
 Release:        1%{?dist}
 Summary:        Bluefin branding
 
@@ -85,7 +85,7 @@ Logos for CLI applications like Fastfetch
 
 %package fastfetch
 Summary:        Fastfetch configuration for Bluefin
-Version:        0.2.2
+Version:        0.2.3
 License:        CC-BY-CA
 
 %description fastfetch

--- a/packages/bluefin/fastfetch/fastfetch.jsonc
+++ b/packages/bluefin/fastfetch/fastfetch.jsonc
@@ -61,7 +61,8 @@
     },
     {
       "type": "disk",
-      "key": ""
+      "key": "",
+      "hideFS": "overlay"
     },
     {
       "type": "display",


### PR DESCRIPTION
Follows #490 

This hides the overlay fs that comes with composefs.

This requires fastfetch 2.44 ! (Currently 2.43 is available on fedoras repo)
The parameter is ignored if used with fastfetch 2.42 (I've successfully tested it)

Tested with fastfetch from brew 
`/home/linuxbrew/.linuxbrew/Cellar/fastfetch/2.44.0/bin/fastfetch --config packages/bluefin/fastfetch/fastfetch.jsonc`
And with fastfetch 2.41 (overlay appears but no errors)
`/usr/bin/fastfetch --config packages/bluefin/fastfetch/fastfetch.jsonc `