### PR TITLE
fix(ublue-bling): enable correct bling.sh sourcing from .zshrc or .ba…

### DIFF
--- a/packages/ublue-bling/src/bling.sh
+++ b/packages/ublue-bling/src/bling.sh
@@ -28,7 +28,10 @@ HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-/home/linuxbrew/.linuxbrew}"
 # Atuin allows these flags: "--disable-up-arrow" and/or "--disable-ctrl-r"
 ATUIN_INIT_FLAGS=${ATUIN_INIT_FLAGS:-""}
 
-if [ "$(basename "$SHELL")" = "bash" ]; then
+# override $SHELL with first script argument if passed
+ACTIVE_SHELL="${1:=${SHELL}}"
+
+if [ "$(basename "$ACTIVE_SHELL")" = "bash" ]; then
     [ -f "/etc/profile.d/bash-preexec.sh" ] && . "/etc/profile.d/bash-preexec.sh"
     [ -f "/usr/share/bash-prexec" ] && . "/usr/share/bash-prexec"
     [ -f "/usr/share/bash-prexec.sh" ] && . "/usr/share/bash-prexec.sh"
@@ -36,7 +39,7 @@ if [ "$(basename "$SHELL")" = "bash" ]; then
     [ "$(command -v starship)" ] && eval "$(starship init bash)"
     [ "$(command -v atuin)" ] && eval "$(atuin init bash ${ATUIN_INIT_FLAGS})"
     [ "$(command -v zoxide)" ] && eval "$(zoxide init bash)"
-elif [ "$(basename "$SHELL")" = "zsh" ]; then
+elif [ "$(basename "$ACTIVE_SHELL")" = "zsh" ]; then
     [ "$(command -v starship)" ] && eval "$(starship init zsh)"
     [ "$(command -v atuin)" ] && eval "$(atuin init zsh ${ATUIN_INIT_FLAGS})"
     [ "$(command -v zoxide)" ] && eval "$(zoxide init zsh)"

--- a/packages/ublue-bling/src/ublue-bling
+++ b/packages/ublue-bling/src/ublue-bling
@@ -122,7 +122,7 @@ EOF
             echo 'Adding bling to your .zshrc 💤💤💤'
             cat<<EOF >> "${ZDOTDIR:-$HOME}/.zshrc"
 ### bling.sh source start
-test -f $BLING_CLI_DIRECTORY/bling.sh && source $BLING_CLI_DIRECTORY/bling.sh
+test -f $BLING_CLI_DIRECTORY/bling.sh && source $BLING_CLI_DIRECTORY/bling.sh "zsh"
 ### bling.sh source end
 EOF
         ;;
@@ -130,7 +130,7 @@ EOF
             echo 'Adding bling to your .bashrc 💥💥💥'
             cat<<EOF >> "${HOME}/.bashrc"
 ### bling.sh source start
-test -f $BLING_CLI_DIRECTORY/bling.sh && source $BLING_CLI_DIRECTORY/bling.sh
+test -f $BLING_CLI_DIRECTORY/bling.sh && source $BLING_CLI_DIRECTORY/bling.sh "bash"
 ### bling.sh source end
 EOF
         ;;


### PR DESCRIPTION
…shrc regardless of default /usr/bin/bash setting

This should resolve https://github.com/ublue-os/packages/issues/131

The issue was that bling.sh was using the SHELL variable to choose between using bash or zsh specific logic. If a user is using zsh without changing their default shell (as recommended) then the script was invoking the incorrect block.