### PR TITLE
fix(search-light): enable gnome 48 patches for epel 10 builds

### DIFF
--- a/staging/gnome-shell-extension-search-light/gnome-shell-extension-search-light.spec
+++ b/staging/gnome-shell-extension-search-light/gnome-shell-extension-search-light.spec
@@ -7,7 +7,7 @@
 
 Name:        gnome-shell-extension-search-light
 Version:     0.0.0
-Release:     2%{gitrel}%{?dist}
+Release:     3%{gitrel}%{?dist}
 Summary:     Take the apps search out of overview
 
 Group:       User Interface/Desktops
@@ -31,7 +31,7 @@ This is a Gnome Shell extension that takes the apps search widget out of Overvie
 %prep
 %autosetup -n search-light-%{commit} -N
 
-%if 0%{?fedora} >= 42 || 0%{?rhel} >= 11
+%if 0%{?fedora} >= 42 || 0%{?rhel} >= 10
 %patch -P 0 -p1
 %endif
 


### PR DESCRIPTION

We got the GNOME 48 backports for EL10 now!!! Should be fine building it with the patches :)