### PR TITLE
Update ublue-os-just.spec to 0.47

### DIFF
--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -1,6 +1,6 @@
 Name:           ublue-os-just
 Vendor:         ublue-os
-Version:        0.46
+Version:        0.47
 Release:        2%{?dist}
 Summary:        ublue-os just integration
 License:        Apache-2.0
@@ -89,6 +89,9 @@ just --completions fish | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{fis
 %{fish_completions_dir}/ujust.fish
 
 %changelog
+* The Jun 03 2025 omid-1985 <omid.1985@gmail.com> - 0.47
+- Add brew cleanup maintenance tasks.
+
 * Thu May 22 2025 renner0e <Renner03@protonmail.com> - 0.46
 - Generate ujust shell completions at build time
 


### PR DESCRIPTION
Bump to version 0.47 for added brew cleanup maintenance tasks.