### PR TITLE
chore: revert logomenu to bbbc77836d1bb853f4bbaf683674c3bbae19cf66

### DIFF
--- a/staging/gnome-shell-extension-logo-menu/gnome-shell-extension-logo-menu.spec
+++ b/staging/gnome-shell-extension-logo-menu/gnome-shell-extension-logo-menu.spec
@@ -1,13 +1,13 @@
 %global uuid logomenu@aryan_k
 
 # renovate: datasource=git-refs depName=https://github.com/Aryan20/Logomenu versioning=loose currentValue=main
-%global commit 89e0e4d84b97e65f0787e195663090f157dd82ae
+%global commit bbbc77836d1bb853f4bbaf683674c3bbae19cf66
 %global shortcommit %(c=%{commit}; echo ${c:0:7})
 %global gitrel      .git%{shortcommit}
 
 Name:          gnome-shell-extension-logo-menu
 Version:       0.0.0
-Release:       4%{gitrel}%{?dist}
+Release:       5%{gitrel}%{?dist}
 Summary:       Quick access menu for the GNOME panel
 
 Group:         User Interface/Desktops


### PR DESCRIPTION
Fully reverts https://github.com/ublue-os/packages/pull/516, since only the patch was reverted previously