### PR TITLE
chore: bump logomenu spec to 1.0.1

### DIFF
--- a/staging/gnome-shell-extension-logo-menu/gnome-shell-extension-logo-menu.spec
+++ b/staging/gnome-shell-extension-logo-menu/gnome-shell-extension-logo-menu.spec
@@ -6,8 +6,8 @@
 %global gitrel      .git%{shortcommit}
 
 Name:          gnome-shell-extension-logo-menu
-Version:       0.0.0
-Release:       5%{gitrel}%{?dist}
+Version:       1.0.1
+Release:       0%{gitrel}%{?dist}
 Summary:       Quick access menu for the GNOME panel
 
 Group:         User Interface/Desktops


### PR DESCRIPTION
This should force new builds to use the new package