### PR TITLE
fix(ublue-setup-services): set service user as root

### DIFF
--- a/packages/ublue-setup-services/src/services/ublue-system-setup.service
+++ b/packages/ublue-setup-services/src/services/ublue-system-setup.service
@@ -6,6 +6,7 @@ Before=systemd-user-sessions.service
 [Service]
 Type=simple
 ExecStart=/usr/libexec/ublue-system-setup
+User=root
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Ensures that $HOME is set so libsetup doesn't complain about it being unbound