### PR TITLE
fix: unbind ctrl-alt-\

### DIFF
--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -2,7 +2,7 @@
 %global vendor bluefin
 
 Name:           bluefin
-Version:        0.3.8
+Version:        0.3.9
 Release:        1%{?dist}
 Summary:        Bluefin branding
 

--- a/packages/bluefin/schemas/etc/dconf/db/distro.d/02-bluefin-keybindings
+++ b/packages/bluefin/schemas/etc/dconf/db/distro.d/02-bluefin-keybindings
@@ -21,7 +21,4 @@ binding='<Control><Alt>BackSpace'
 command="flatpak run com.jeffser.Alpaca"
 name='Launch Alpaca'
 
-[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4]
-binding='<Control><Alt>backslash'
-command="bazaar --search"
-name='Search on Bazaar'
+

--- a/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -117,7 +117,7 @@ folder-children=['Games', 'GamingUtilities', 'Utilities', 'Containers', 'Wine', 
 
 # Modifying shortcut actions for custom0, custom1, custom2, etc. are recognized as relocatable schemas
 [org.gnome.settings-daemon.plugins.media-keys]
-custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/']
+custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/']
 home=['<Super>e']
 
 # Ptyxis color palette is recognized as a relocatable schema


### PR DESCRIPTION
Bazaar was inititally intended as a quickfire search but turned into a full g-s replacement, so we don't need this, and as pointed out in the forums, we shouldn't just expect new keyboard shortcuts to be available as users may be using this. 