### PR TITLE
chore: bump release version of ublue-os-libvirt-workarounds

### DIFF
--- a/packages/ublue-os-libvirt-workarounds/ublue-os-libvirt-workarounds.spec
+++ b/packages/ublue-os-libvirt-workarounds/ublue-os-libvirt-workarounds.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-libvirt-workarounds
 Vendor:         ublue-os
 Version:        1.1
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Services to workaround libvirt issues
 License:        Apache-2.0
 URL:            https://github.com/ublue-os/packages


### PR DESCRIPTION
There are a few different builds on Copr for `ublue-os-libvirt-workarounds-1.1-1`. In some of them `/usr/lib/systemd/system-preset/54-ublue-os-libvirt-workarounds.preset` has the contents

```
enable ublue-os-libvirt-workarounds.service
```

and in others, it has

```
enable ublue-os-libvirt-workaround.service
```

which is a typo. 

![image](https://github.com/user-attachments/assets/802081cb-07c5-479b-84bb-75f4497f0d80)

In Blue95, it has grabbed the incorrect one and the service is no longer enabled because the preset is now technically disabled because of the typo:
```
$ cat /usr/lib/systemd/system-preset/54-ublue-os-libvirt-workarounds.preset 
enable ublue-os-libvirt-workaround.service
$ systemctl status ublue-os-libvirt-workarounds.service
○ ublue-os-libvirt-workarounds.service - Workaround to relabel libvirt files and directories
     Loaded: loaded (/usr/lib/systemd/system/ublue-os-libvirt-workarounds.service; disabled; preset: disabled)
    Drop-In: /usr/lib/systemd/system/service.d
             └─10-timeout-abort.conf
     Active: inactive (dead)
```

Bumping the release version should fix this discrepancy.
