### PR TITLE
fix(bazaar): add gvfs dependency

### DIFF
--- a/staging/bazaar/bazaar.spec
+++ b/staging/bazaar/bazaar.spec
@@ -5,7 +5,7 @@
 
 Name:           bazaar
 Version:        {{{ git_dir_version }}}.%{shortcommit}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        A new app store idea for GNOME. 
 
 License:        GPL-3.0-only
@@ -23,6 +23,7 @@ BuildRequires:  desktop-file-utils
 BuildRequires:  libyaml-devel
 Requires:       glycin-libs
 Requires:       libadwaita
+Requires:       gvfs
 
 %description
 %summary


### PR DESCRIPTION
kde images (except bazzite, already happens to pull it in) don't ship with `gvfs` and would throw this error without it:

```
could not retrieve remote content: failed to download icon from uri https://dl.flathub.org/repo/logo.svg for remote 'flathub': GLib error: Operation not supported
```

![image](https://github.com/user-attachments/assets/c898941a-35c0-4bac-b786-18c160764f8f)
