### PR TITLE
feat(aurora): add start-here logo

### DIFF
--- a/packages/aurora/aurora.spec
+++ b/packages/aurora/aurora.spec
@@ -24,7 +24,7 @@ Branding for Aurora-related projects
 %install
 install -Dpm0644 -t %{buildroot}%{_datadir}/ublue-os/aurora-logos/symbols/ cli-logos/symbols/*
 
-mkdir -p %{buildroot}%{_datadir}/icons/hicolor/scalable/places/
+mkdir -p %{buildroot}%{_datadir}/icons/hicolor/scalable/{apps,places}/
 install -Dpm0644 -t %{buildroot}%{_datadir}/pixmaps/ logos/fedora_logo_med.png
 install -Dpm0644 -t %{buildroot}%{_datadir}/pixmaps/ logos/fedora_whitelogo.svg
 install -Dpm0644 -t %{buildroot}%{_datadir}/pixmaps/ logos/fedora-logo.{png,svg}
@@ -34,6 +34,8 @@ install -Dpm0644 -t %{buildroot}%{_datadir}/pixmaps/ logos/system-logo{,-white}.
 install -Dpm0644 -t %{buildroot}%{_datadir}/icons/hicolor/scalable/ logos/distributor-logo{,-white}.svg
 ln -sr %{buildroot}%{_datadir}/icons/hicolor/scalable/distributor-logo.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/places/distributor-logo.svg
 ln -sr %{buildroot}%{_datadir}/icons/hicolor/scalable/distributor-logo-white.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/places/distributor-logo-white.svg
+ln -sr %{buildroot}%{_datadir}/icons/hicolor/scalable/distributor-logo-white.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/places/start-here.svg
+ln -sr %{buildroot}%{_datadir}/icons/hicolor/scalable/distributor-logo-white.svg %{buildroot}%{_datadir}/icons/hicolor/scalable/apps/start-here.svg
 
 install -Dpm0644 -t %{buildroot}%{_datadir}/ublue-os/ fastfetch/fastfetch.jsonc
 install -Dpm0644 -t %{buildroot}%{_datadir}/plymouth/themes/spinner/ plymouth/themes/spinner/*.png
@@ -130,6 +132,7 @@ Replacement logos for KDE
 %{_datadir}/pixmaps/system-logo{,-white}.png
 %{_datadir}/icons/hicolor/scalable/distributor-logo{,-white}.svg
 %{_datadir}/icons/hicolor/scalable/places/distributor-logo{,-white}.svg
+%{_datadir}/icons/hicolor/scalable/{apps,places}/start-here.svg
 
 
 %package cli-logos

--- a/packages/aurora/aurora.spec
+++ b/packages/aurora/aurora.spec
@@ -2,7 +2,7 @@
 %global vendor aurora
 
 Name:           aurora
-Version:        0.1.16
+Version:        0.1.17
 Release:        1%{?dist}
 Summary:        Aurora branding
 
@@ -110,7 +110,7 @@ install -Dpm0644 -t %{buildroot}/%{_datadir}/ublue-os/discover kde-config/discov
 
 %package logos
 Summary:        Logos for KDE
-Version:        0.1.5
+Version:        0.1.6
 License:        CC-BY-SA
 Provides: fedora-logos
 Provides: centos-logos


### PR DESCRIPTION
adds our white logo as the start-here logo that is used in the default configuration of
the KDE Plasma Panel. That value is only set on initial user login of
fedora kinoite, so this fixes the inconsistency that rebasers have the
purple logo instead of the white one.

For consistency with fedora-logos I put it in scalable/{apps,places}