### PR TITLE
feat: Packaging release for `usb-storage-optimized-async`

### DIFF
--- a/packages/usb-storage-optimized-async/src/01-usb-storage-optimized-async-service.preset
+++ b/packages/usb-storage-optimized-async/src/01-usb-storage-optimized-async-service.preset
@@ -1,0 +1,1 @@
+enable usb-storage-optimized-async-service.service

--- a/packages/usb-storage-optimized-async/src/usb-storage-optimized-async-service
+++ b/packages/usb-storage-optimized-async/src/usb-storage-optimized-async-service
@@ -2,7 +2,8 @@
 
 set -x
 
-# Oneshot service script for usb-storage-optimized-async, as a fallback if USB storage device mounts too early through udev
+# Oneshot service script for usb-storage-optimized-async, as a fallback when udev triggers too early during the boot
+# for the script to apply (before login shell), so no USB replug to make the rule work is needed in that case
 
 # Limit the amount of disk cache for USB storage devices, to ensure that writing speed is correct, as opposed to async
 # sync is too slow & has a risk for deteorating USB storage data health, so that's why this balanced solution is being done

--- a/packages/usb-storage-optimized-async/src/usb-storage-optimized-async-service
+++ b/packages/usb-storage-optimized-async/src/usb-storage-optimized-async-service
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -x
+
+# Oneshot service script for usb-storage-optimized-async, as a fallback if USB storage device mounts too early through udev
+
+# Limit the amount of disk cache for USB storage devices, to ensure that writing speed is correct, as opposed to async
+# sync is too slow & has a risk for deteorating USB storage data health, so that's why this balanced solution is being done
+# See the link below for more details
+# https://github.com/ublue-os/packages/issues/677
+#
+# Credits:
+# - Megavolt (from Manjaro forums): for making it possible through his benchmarks, testings, findings & initial udev rule + script
+
+get_usb_storage_block() {
+    idV="${1%:*}"
+    idP="${1#*:}"
+    for path in $(find /sys/ -name idVendor | rev | cut -d/ -f 2- | rev); do
+        if grep -q "$idV" "$path/idVendor"; then
+            if grep -q "$idP" "$path/idProduct"; then
+                basename "$(realpath --relative-base="$path" /sys/block/* | grep -vm 1 "^/")" 2>/dev/null
+            fi
+        fi
+    done
+}
+
+readarray -t USB_VENDOR_MODEL < <(lsusb -v -t | awk '/Driver=usb-storage/{getline; gsub(/^[ \t]+|[ \t]+$/, "", $0); print $0}' | awk '/ID/{print $2}')
+if [ "${#USB_VENDOR_MODEL[@]}" -eq 0 ]; then
+  exit 0
+fi
+for usb_vendor_model in "${USB_VENDOR_MODEL[@]}"; do
+    usb_vendor="$(echo "$usb_vendor_model" | awk -F':' '{print $1}')"
+    usb_model="$(echo "$usb_vendor_model" | awk -F':' '{print $2}')"
+    block_device="$(get_usb_storage_block "$usb_vendor:$usb_model")"
+    strict_limit=1
+    # apply strict limit to max_bytes of disk cache
+    if [ -e "/sys/block/${block_device}" ]; then
+      echo "${strict_limit}" > "/sys/block/${block_device}/bdi/strict_limit"
+    else
+      echo "This block device ${block_device} doesn't exist"
+      continue
+    fi
+    current_usb_speed=$(lsusb -t -v | awk -v vendor_id="${usb_vendor}" -v model_id="${usb_model}" '$0 ~ vendor_id ":" model_id {split(prev, a, " "); print a[length(a)]} {prev=$0}' | grep -o '[0-9]*\.[0-9]*\|[0-9]*')
+    # Handle the case if float is with , as decimal separator
+    if [[ $(echo "${current_usb_speed}" | wc -l) -gt 1 ]]; then
+      echo "Cannot determine current USB speed for this device to write custom max_bytes dirty value"
+      continue
+    fi
+    # If current USB speed is somehow not determined or wrongly parsed, then stop the script
+    # if it's empty or if USB speed is not in integer or floats
+    if [[ -z "${current_usb_speed}" ]] || [[ ! "${current_usb_speed}" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]; then
+      echo "Cannot determine current USB speed for the device to write custom max_bytes dirty value"
+      continue
+    fi
+    buffer_time="0.05"
+    safety_factor="1.3"
+    max_bytes_calculation=$(echo "((${current_usb_speed} / 8) * ${buffer_time} * ${safety_factor}) * 1024 * 1024" | bc)
+    max_bytes=$(echo "${max_bytes_calculation}" | awk '{print ($1 - int($1) > 0.5) ? int($1) + 1 : int($1)}')
+    # General max_bytes ideal value results (thanks to MegaVolt from Manjaro forums):
+    # 12.5MB/s: 62915
+    # 100MB/s: 817889
+    # 500MB/s: 4225761
+    # 1000MB/s: 8514437
+    # 5000MB/s: 42593157
+    # 10000MB/s: 85196800
+    # apply bandwidth defined value
+    if [ -e "/sys/block/${block_device}" ]; then
+      echo "${max_bytes}" > "/sys/block/${block_device}/bdi/max_bytes"
+    else
+      echo "This block device ${block_device} doesn't exist"
+      continue
+    fi
+done

--- a/packages/usb-storage-optimized-async/src/usb-storage-optimized-async-service.service
+++ b/packages/usb-storage-optimized-async/src/usb-storage-optimized-async-service.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Oneshot service for usb-storage-optimized-async, as a fallback if USB storage device mounts too early through udev
+Description=Oneshot service script for usb-storage-optimized-async, as a fallback when udev triggers too early during the boot, so no USB replug is needed in that case for the rule to apply
 Before=systemd-user-sessions.service
 
 [Service]

--- a/packages/usb-storage-optimized-async/src/usb-storage-optimized-async-service.service
+++ b/packages/usb-storage-optimized-async/src/usb-storage-optimized-async-service.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Oneshot service for usb-storage-optimized-async, as a fallback if USB storage device mounts too early through udev
+Before=systemd-user-sessions.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/usb-dirty-pages-service
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/usb-storage-optimized-async/src/usb-storage-optimized-async-udev
+++ b/packages/usb-storage-optimized-async/src/usb-storage-optimized-async-udev
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -x
+
+# udev rule for usb-storage-optimized-async
+
+# Limit the amount of disk cache for USB storage devices, to ensure that writing speed is correct, as opposed to async
+# sync is too slow & has a risk for deteorating USB storage data health, so that's why this balanced solution is being done
+# See the link below for more details
+# https://github.com/ublue-os/packages/issues/677
+#
+# Credits:
+# - Megavolt (from Manjaro forums): for making it possible through his benchmarks, testings, findings & initial udev rule + script
+
+block_device="${1}"
+# apply strict limit to max_bytes of disk cache
+strict_limit=1
+echo "${strict_limit}" > "/sys/block/${block_device}/bdi/strict_limit"
+
+vendor_id="${2}"
+model_id="${3}"
+
+# Determine current USB device speed, as ATTRS{speed} is unreliable - it detects xHCI USB speed instead of proper USB speed
+current_usb_speed=$(lsusb -t -v | awk -v vendor_id="${vendor_id}" -v model_id="${model_id}" '$0 ~ vendor_id ":" model_id {split(prev, a, " "); print a[length(a)]} {prev=$0}' | grep -o '[0-9]*\.[0-9]*\|[0-9]*')
+
+# Handle the case if float is with , as a decimal separator
+if [[ $(echo "${current_usb_speed}" | wc -l) -gt 1 ]]; then
+  echo "Cannot determine current USB speed for the device to write custom max_bytes dirty value"
+  echo "Exiting"
+  exit 1
+fi
+
+# If current USB speed is somehow not determined or wrongly parsed, then stop the script
+# if it's empty or if USB speed is not in integer or floats
+if [[ -z "${current_usb_speed}" ]] || [[ ! "${current_usb_speed}" =~ ^-?[0-9]+(\.[0-9]+)?$ ]]; then
+  echo "Cannot determine current USB speed for the device to write custom max_bytes dirty value"
+  echo "Exiting"
+  exit 1
+fi
+
+buffer_time="0.05"
+safety_factor="1.3"
+max_bytes_calculation=$(echo "((${current_usb_speed} / 8) * ${buffer_time} * ${safety_factor}) * 1024 * 1024" | bc)
+max_bytes=$(echo "${max_bytes_calculation}" | awk '{print ($1 - int($1) > 0.5) ? int($1) + 1 : int($1)}')
+# General max_bytes ideal value results (thanks to MegaVolt from Manjaro forums):
+# 12.5MB/s: 62915
+# 100MB/s: 817889
+# 500MB/s: 4225761
+# 1000MB/s: 8514437
+# 5000MB/s: 42593157
+# 10000MB/s: 85196800
+
+# apply bandwidth defined value
+echo "${max_bytes}" > "/sys/block/${block_device}/bdi/max_bytes"

--- a/packages/usb-storage-optimized-async/src/zz1-usb-storage-optimized-async-udev.rules
+++ b/packages/usb-storage-optimized-async/src/zz1-usb-storage-optimized-async-udev.rules
@@ -1,0 +1,1 @@
+ACTION=="add|change", KERNEL=="sd[a-z]", ENV{ID_USB_TYPE}=="disk", RUN+="/usr/bin/usb-dirty-pages-udev '%k' '%E{ID_USB_VENDOR_ID}' '%E{ID_USB_MODEL_ID}'"

--- a/packages/usb-storage-optimized-async/usb-storage-optimized-async.spec
+++ b/packages/usb-storage-optimized-async/usb-storage-optimized-async.spec
@@ -34,10 +34,10 @@ install -Dm0644 ./src/%{name}-service.service -t %{buildroot}%{_unitdir}/%{name}
 install -Dm0644 ./src/01-%{name}-service.preset -t %{buildroot}%{_presetdir}/01-%{name}-service.preset
 
 %post
-%systemd_post %{name}.service
+%systemd_post %{name}-service.service
 
 %preun
-%systemd_preun %{name}.service
+%systemd_preun %{name}-service.service
 
 %files
 %{_bindir}/%{name}-udev

--- a/packages/usb-storage-optimized-async/usb-storage-optimized-async.spec
+++ b/packages/usb-storage-optimized-async/usb-storage-optimized-async.spec
@@ -1,0 +1,51 @@
+Name:           usb-storage-optimized-async
+Version:        1.0
+Release:        1%{?dist}
+Summary:        Optimize async for USB storage devices minimizing the potential for data corruption
+
+License:        Apache-2.0
+URL:            https://github.com/ublue-os/packages
+VCS:            {{{ git_dir_vcs }}}
+Source:         {{{ git_dir_pack }}}
+
+BuildArch:      noarch
+BuildRequires:  systemd-rpm-macros
+Requires:       bash
+Requires:       gawk
+Requires:       grep
+Requires:       coreutils
+Requires:       findutils
+Requires:       bc
+Requires:       usbutils
+Requires:       systemd
+Requires:       systemd-udev
+
+%description
+Optimize async for USB storage devices minimizing the potential for data corruption
+
+%prep
+{{{ git_dir_setup_macro }}}
+
+%install
+install -Dm0755 ./src/%{name}-udev -t %{buildroot}%{_bindir}/%{name}-udev
+install -Dm0644 ./src/zz1-%{name}-udev.rules -t %{buildroot}%{_udevrulesdir}/zz1-%{name}-udev.rules
+install -Dm0755 ./src/%{name}-service -t %{buildroot}%{_bindir}/%{name}-service
+install -Dm0644 ./src/%{name}-service.service -t %{buildroot}%{_unitdir}/%{name}-service.service
+install -Dm0644 ./src/01-%{name}-service.preset -t %{buildroot}%{_presetdir}/01-%{name}-service.preset
+
+%post
+%systemd_post %{name}.service
+
+%preun
+%systemd_preun %{name}.service
+
+%files
+%{_bindir}/%{name}-udev
+%{_udevrulesdir}/zz1-%{name}-udev.rules
+%{_bindir}/%{name}-service
+%{_unitdir}/%{name}-service.service
+%{_presetdir}/01-%{name}-service.preset
+
+%changelog
+* Fri Jul 04 2025 Fifty Dinar <srbaizoki4@tuta.io> - 1.0-1
+- Initial release


### PR DESCRIPTION
The reason why I don't use `ublue-os` prefix in the naming is because It's not related to Ublue-specific additions.
This package can be used anywhere on Linux if all dependencies are satisfied, which can be seen in RPM spec.

Let me know if some RPM spec modifications are needed.

See below for more informations about why I made this package.

Closes: https://github.com/ublue-os/packages/issues/677