### PR TITLE
fix(bazaar): explictly require libdex 0.9.1

### DIFF
--- a/staging/bazaar/bazaar.spec
+++ b/staging/bazaar/bazaar.spec
@@ -5,7 +5,7 @@
 
 Name:           bazaar
 Version:        {{{ git_dir_version }}}.%{shortcommit}
-Release:        3%{?dist}
+Release:        4%{?dist}
 Summary:        A new app store idea for GNOME. 
 
 License:        GPL-3.0-only
@@ -30,6 +30,7 @@ Requires:       glycin-libs
 Requires:       libadwaita
 Requires:       libsoup3
 Requires:       json-glib
+Requires:       libdex = 0.9.1
 
 %description
 %summary


### PR DESCRIPTION
libdex 0.10.1 breaks bazaar in VMs and low spec PCs

this centralizes https://github.com/ublue-os/aurora/pull/713 and respective PR to bluefin

this is probably what I should have done in the first place lol
This should fix bazaar assuming libdex doesn't get upgraded in the image build somewhere


```
sudo dnf5 repoquery --whatrequires libdex | grep -v "i686\|bazaar"
Updating and loading repositories:
Repositories loaded.
gnome-builder-0:48.0-1.fc42.x86_64
gnome-builder-0:48.2-1.fc42.x86_64
libdex-devel-0:0.10.1-1.fc42.x86_64
libdex-devel-0:0.9.1-1.fc42.x86_64
libdex-devel-docs-0:0.10.1-1.fc42.noarch
libdex-devel-docs-0:0.9.1-1.fc42.noarch
libsysprof-0:48.0-1.fc42.x86_64
sysprof-0:48.0-1.fc42.x86_64
sysprof-agent-0:48.0-1.fc42.x86_64
sysprof-cli-0:48.0-1.fc42.x86_64
```
