### PR TITLE
chore: bump kcm_ublue to 0.6.0

### DIFF
--- a/packages/kcm_ublue/kcm_ublue.spec
+++ b/packages/kcm_ublue/kcm_ublue.spec
@@ -1,4 +1,4 @@
-%global majmin_ver_kcm 0.5.8
+%global majmin_ver_kcm 0.6.0
 
 Name:           kcm_ublue
 Version:        %{majmin_ver_kcm}


### PR DESCRIPTION
Fixes https://github.com/ledif/kcm_ublue/issues/19.
<img width="1594" height="1214" alt="image" src="https://github.com/user-attachments/assets/60c5dcdb-b4f7-40c3-b0f0-9eb1f7791cf8" />
