### PR TITLE
fix: syntax error k8s Brewfile

### DIFF
--- a/packages/bluefin/schemas/usr/share/ublue-os/homebrew/kubernetes.Brewfile
+++ b/packages/bluefin/schemas/usr/share/ublue-os/homebrew/kubernetes.Brewfile
@@ -1,7 +1,7 @@
 tap "buildpacks/tap"
 brew "cdk8s"
 tap "k0sproject/tap"
-brew "k0sctl
+brew "k0sctl"
 brew "k3sup"
 brew "kind"
 brew "dagger"


### PR DESCRIPTION
Fixes syntax error in Brewfile for installing k8s dev tools (`ujust install-k8s-dev-tools`).