### PR TITLE
feat(bluefin-schemas): add default shortcut for Gradia and Smile

### DIFF
--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -2,7 +2,7 @@
 %global vendor bluefin
 
 Name:           bluefin
-Version:        0.3.18
+Version:        0.3.19
 Release:        1%{?dist}
 Summary:        Bluefin branding
 
@@ -110,7 +110,7 @@ Plymouth logo customization for Bluefin
 
 
 %package schemas
-Version:        0.2.11
+Version:        0.2.12
 Summary:        GNOME Schemas for Bluefin
 
 %description schemas

--- a/packages/bluefin/schemas/etc/dconf/db/distro.d/02-bluefin-keybindings
+++ b/packages/bluefin/schemas/etc/dconf/db/distro.d/02-bluefin-keybindings
@@ -21,4 +21,12 @@ binding='<Control><Alt>BackSpace'
 command="flatpak run com.jeffser.Alpaca"
 name='Launch Alpaca'
 
+[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4]
+binding='<Super>Print'
+command="flatpak run be.alexandervanhee.gradia --screenshot"
+name='Take and edit screenshot'
 
+[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5]
+binding='<Control><Alt>space'
+command="flatpak run it.mijorus.smile"
+name='Open up the emoji picker'

--- a/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -117,7 +117,7 @@ folder-children=['Games', 'GamingUtilities', 'Utilities', 'Containers', 'Wine', 
 
 # Modifying shortcut actions for custom0, custom1, custom2, etc. are recognized as relocatable schemas
 [org.gnome.settings-daemon.plugins.media-keys]
-custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/']
+custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/']
 home=['<Super>e']
 
 # Ptyxis color palette is recognized as a relocatable schema


### PR DESCRIPTION
Gradia -> Super+Printsc
Smile -> Ctrl+Alt+Space (as super conflicts with searchlight)

Signed-off-by: Tulip Blossom <tulilirockz@proton.me>
