### PR TITLE
fix(bluefin): bump package shemas version for flatpakref fix

### DIFF
--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -110,7 +110,7 @@ Plymouth logo customization for Bluefin
 
 
 %package schemas
-Version:        0.2.11
+Version:        0.2.12
 Summary:        GNOME Schemas for Bluefin
 
 %description schemas


### PR DESCRIPTION
Forgot to bump the package schema version for the flatpakref fix.