### PR TITLE
fix(ublue-os-media-automount): match fstab entries by uuid

### DIFF
--- a/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
+++ b/packages/ublue-os-media-automount-udev/ublue-os-media-automount-udev.spec
@@ -1,6 +1,6 @@
 Name:           ublue-os-media-automount-udev
 Vendor:         ublue-os
-Version:        0.18
+Version:        0.19
 Release:        1%{?dist}
 Summary:        udev rules to mount non-removable disk partitions
 
@@ -35,6 +35,9 @@ install -p -Dm0644 ./ublue-os-media-automount.conf %{buildroot}%{_tmpfilesdir}/u
 %{_tmpfilesdir}/ublue-os-media-automount.conf
 
 %changelog
+* Sat Aug 02 2025 Pim Vermeer <pim.vermeer@gmail.com> - 0.19
+- fix: Match fstab entries by uuid
+
 * Wed Jul 23 2025 JMarcosHP <58377032+JMarcosHP@users.noreply.github.com> - 0.18
 - feat: Add x-gvfs-show mount option for partition visibility in Gnome
 


### PR DESCRIPTION
Issue: certain partitions are mounted in my system while explicitly disabled in `fstab`.

I noticed in recent updates in Bazzite that partitions got mounted on boot that I had disabled in `fstab`. Further investigation revealed that this service is responsible. The current method with manually parsing `fstab` and then look up the filesystem with `findfs` fails when using certain identifiers. This method also seems a bit hacky and prone to errors. 
This leads to unexpected behavior where the different way a `fstab` entry can match with a partition does not always finds a match so the partition gets mounted anyway and possibly the wrong path.

I changed this to use 'findmnt' which will return the 'partuuid' for all of the fstab entries, regardless of how it's defined. `lsblk`  Also outputs the `partuuid` so it can be matched with 'lsblk' output.