### PR TITLE
fix(ublue-brew): add zstd to Requires

### DIFF
--- a/packages/ublue-brew/ublue-brew.spec
+++ b/packages/ublue-brew/ublue-brew.spec
@@ -16,6 +16,7 @@ Source2:        https://github.com/ublue-os/packages/releases/download/%{homebre
 
 BuildRequires:  systemd-rpm-macros
 Requires:       gcc
+Requires:       zstd
 
 %description
 Homebrew integration for Universal Blue systems


### PR DESCRIPTION
The `brew-setup.service` has the command `/usr/bin/tar --zstd -xvf /usr/share/homebrew.tar.zst -C /tmp/homebrew ` which requires the `zstd` package at runtime.

Reported in https://github.com/winblues/vauxite/issues/14.