### PR TITLE
fix: remove claude-code from aurora-ai recipe

### DIFF
--- a/packages/aurora/aurora.spec
+++ b/packages/aurora/aurora.spec
@@ -2,7 +2,7 @@
 %global vendor aurora
 
 Name:           aurora
-Version:        0.1.28
+Version:        0.1.29
 Release:        1%{?dist}
 Summary:        Aurora branding
 
@@ -183,7 +183,7 @@ Plymouth logo customization for Aurora
 
 
 %package schemas
-Version:        0.1.11
+Version:        0.1.12
 Summary:        KDE Schemas for Aurora
 
 %description schemas

--- a/packages/aurora/schemas/usr/share/ublue-os/homebrew/aurora-ai.Brewfile
+++ b/packages/aurora/schemas/usr/share/ublue-os/homebrew/aurora-ai.Brewfile
@@ -4,4 +4,4 @@ brew "codex"
 brew "gemini-cli"
 brew "mods"
 brew "ramalama"
-brew "claude-code"
+


### PR DESCRIPTION
claude-code from brew doesn't really work properly in Linux