### PR TITLE
fix(motd): fix URLs that extend beyond the character limit

### DIFF
--- a/packages/ublue-motd/src/ublue-motd
+++ b/packages/ublue-motd/src/ublue-motd
@@ -67,4 +67,4 @@ sed -e "s/%IMAGE_NAME%/$IMAGE_NAME_ESCAPED/g" \
 	-e "s/%IMAGE_TAG%/$IMAGE_TAG_ESCAPED/g" \
 	-e "s/%TIP%/$TIP_ESCAPED/g" \
 	-e "s/%KEY_WARN%/$KEY_WARN_ESCAPED/g" \
-	"$TEMPLATE_FILE" | tr '~' '\n' | /usr/bin/glow -s "${THEMES_DIRECTORY}/${THEME}.json" -w 78 -
+	"$TEMPLATE_FILE" | tr '~' '\n' | /usr/bin/glow -s "${THEMES_DIRECTORY}/${THEME}.json" -w $(tput cols) -

--- a/packages/ublue-motd/ublue-motd.spec
+++ b/packages/ublue-motd/ublue-motd.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-motd
-Version:        0.2.5
+Version:        0.2.6
 Release:        1%{?dist}
 Summary:        MOTD scripts for Universal Blue images
 


### PR DESCRIPTION
this dynamically checks the available column size of the terminal and doesn't hardcode the "78 character limit" for glow which causes long lines with URLs to look weird.

<img width="2539" height="934" alt="image" src="https://github.com/user-attachments/assets/c9efcb8c-8c29-4e07-8b7e-429e33b6f83c" />

This has the disadvantage that it looks all messed up when you spawn a very wide terminal initially and then make it smaller later, because it's not being re-rendered and doesn't consider the smaller size
<img width="1266" height="854" alt="image" src="https://github.com/user-attachments/assets/e88bf9ac-7f5a-45f6-9224-3ad41e2a5ab5" />
