### PR TITLE
fix: brew-upgrade.service ExecStartPost SELinux log messages

### DIFF
--- a/packages/ublue-brew/src/usr/lib/systemd/system/brew-upgrade.service
+++ b/packages/ublue-brew/src/usr/lib/systemd/system/brew-upgrade.service
@@ -14,8 +14,8 @@ Environment=HOMEBREW_REPOSITORY=/home/linuxbrew/.linuxbrew/Homebrew
 ExecStart=/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew upgrade"
 # Prevent Brew from overriding important system binaries like:
 # systemctl, loginctl, dbus-*, python*
-ExecStartPost=-/home/linuxbrew/.linuxbrew/bin/brew unlink systemd
-ExecStartPost=-/home/linuxbrew/.linuxbrew/bin/brew unlink dbus
-ExecStartPost=-/home/linuxbrew/.linuxbrew/bin/brew unlink python
-ExecStartPost=-/home/linuxbrew/.linuxbrew/bin/brew unlink gsettings
-ExecStartPost=-/home/linuxbrew/.linuxbrew/bin/brew unlink bash
+ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink systemd"
+ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink dbus"
+ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink python"
+ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink gsettings"
+ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink bash"


### PR DESCRIPTION
Running `brew-upgrade.service` produces SELinux audit logs from `brew unlink` commands

fixes:
[ublue-os/packages#851](https://github.com/ublue-os/packages/issues/851)
[ublue-os/packages#482](https://github.com/ublue-os/packages/issues/482)
[ublue-os/aurora#543](https://github.com/ublue-os/aurora/issues/543)