### PR TITLE
fix: add search provider and update GNOME settings

### DIFF
--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -2,7 +2,7 @@
 %global vendor bluefin
 
 Name:           bluefin
-Version:        0.3.27
+Version:        0.3.28
 Release:        1%{?dist}
 Summary:        Bluefin branding
 
@@ -110,7 +110,7 @@ Plymouth logo customization for Bluefin
 
 
 %package schemas
-Version:        0.2.15
+Version:        0.2.16
 Summary:        GNOME Schemas for Bluefin
 
 %description schemas

--- a/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -21,7 +21,7 @@ monospace-font-name="JetBrains Mono 16"
 accent-color="slate"
 
 [org.gnome.desktop.search-providers]
-enabled='io.github.kolunmi.Bazaar.desktop'
+enabled = ['io.github.kolunmi.Bazaar.desktop']```
 
 [org.gnome.desktop.sound]
 allow-volume-above-100-percent=true

--- a/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -20,6 +20,9 @@ document-font-name="Adwaita Sans 12"
 monospace-font-name="JetBrains Mono 16"
 accent-color="slate"
 
+[org.gnome.desktop.search-providers]
+enabled='io.github.kolunmi.Bazaar.desktop'
+
 [org.gnome.desktop.sound]
 allow-volume-above-100-percent=true
 theme-name="freedesktop"
@@ -70,11 +73,6 @@ sort-directories-first=true
 [org.gnome.mutter]
 center-new-windows=true
 check-alive-timeout=uint32 20000
-
-[org.gnome.software]
-allow-updates=false
-download-updates=false
-download-updates-notify=false
 
 [com.github.stunkymonkey.nautilus-open-any-terminal]
 terminal='ptyxis'

--- a/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -21,7 +21,7 @@ monospace-font-name="JetBrains Mono 16"
 accent-color="slate"
 
 [org.gnome.desktop.search-providers]
-enabled = ['io.github.kolunmi.Bazaar.desktop']```
+enabled = ['io.github.kolunmi.Bazaar.desktop']
 
 [org.gnome.desktop.sound]
 allow-volume-above-100-percent=true


### PR DESCRIPTION
This turns on bazaar as a search provider.