### PR TITLE
fix: remove carapace from ublue-bling

### DIFF
--- a/packages/ublue-bling/src/bling.sh
+++ b/packages/ublue-bling/src/bling.sh
@@ -39,10 +39,8 @@ if [ "$(basename "$SHELL")" = "bash" ]; then
     [ "$(command -v starship)" ] && eval "$(starship init bash)"
     [ "$(command -v atuin)" ] && eval "$(atuin init bash ${ATUIN_INIT_FLAGS})"
     [ "$(command -v zoxide)" ] && eval "$(zoxide init bash)"
-    [ "$(command -v carapace)" ] && source <(carapace _carapace bash)
 elif [ "$(basename "$SHELL")" = "zsh" ]; then
     [ "$(command -v starship)" ] && eval "$(starship init zsh)"
     [ "$(command -v atuin)" ] && eval "$(atuin init zsh ${ATUIN_INIT_FLAGS})"
     [ "$(command -v zoxide)" ] && eval "$(zoxide init zsh)"
-    [ "$(command -v carapace)" ] && source <(carapace _carapace zsh)
 fi

--- a/packages/ublue-bling/ublue-bling.spec
+++ b/packages/ublue-bling/ublue-bling.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-bling
-Version:        0.1.9
+Version:        0.1.10
 Release:        1%{?dist}
 Summary:        Universal Blue Bling CLI setup scripts
 


### PR DESCRIPTION
Issue #748 is solved by removing carapace from the brew list. This change also removes it from the bash/zsh source.