### PR TITLE
fix: formatting in gschema.override file

### DIFF
--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -2,7 +2,7 @@
 %global vendor bluefin
 
 Name:           bluefin
-Version:        0.3.28
+Version:        0.3.29
 Release:        1%{?dist}
 Summary:        Bluefin branding
 
@@ -110,7 +110,7 @@ Plymouth logo customization for Bluefin
 
 
 %package schemas
-Version:        0.2.16
+Version:        0.2.17
 Summary:        GNOME Schemas for Bluefin
 
 %description schemas

--- a/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -21,7 +21,7 @@ monospace-font-name="JetBrains Mono 16"
 accent-color="slate"
 
 [org.gnome.desktop.search-providers]
-enabled = ['io.github.kolunmi.Bazaar.desktop']
+enabled=['io.github.kolunmi.Bazaar.desktop']
 
 [org.gnome.desktop.sound]
 allow-volume-above-100-percent=true


### PR DESCRIPTION
copilot says there should be no whitespaces here.