### PR TITLE
fix: add gnome software update settings to schema override

### DIFF
--- a/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/packages/bluefin/schemas/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -67,6 +67,11 @@ power-button-action='interactive'
 [org.gtk.Settings.FileChooser]
 sort-directories-first=true
 
+[org.gnome.software]
+allow-updates=false
+download-updates=false
+download-updates-notify=false
+
 [org.gtk.gtk4.Settings.FileChooser]
 sort-directories-first=true
 


### PR DESCRIPTION
GTS still has gnome-software lets keep this in.