### PR TITLE
feat(ublue-brew): unlink rpm on upgrade

### DIFF
--- a/packages/ublue-brew/src/usr/lib/systemd/system/brew-upgrade.service
+++ b/packages/ublue-brew/src/usr/lib/systemd/system/brew-upgrade.service
@@ -19,3 +19,4 @@ ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink dbus
 ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink python"
 ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink gsettings"
 ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink bash"
+ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink rpm"

--- a/packages/ublue-brew/ublue-brew.spec
+++ b/packages/ublue-brew/ublue-brew.spec
@@ -3,7 +3,7 @@
 %define homebrew_release homebrew-2025-05-04-04-03-02
 
 Name:           ublue-brew
-Version:        0.1.9
+Version:        0.1.10
 Release:        1%{?dist}
 Summary:        Homebrew integration for Universal Blue systems
 


### PR DESCRIPTION
On my system, brew at some point installed its own `rpm`, which made things like `rpm -qa` mysteriously return unexpected output.

Ideally, we'd have a better way of handling this. But one more `brew unlink` for now.