### PR TITLE
fix: remove raop default config

### DIFF
--- a/packages/aurora/aurora.spec
+++ b/packages/aurora/aurora.spec
@@ -2,7 +2,7 @@
 %global vendor aurora
 
 Name:           aurora
-Version:        0.1.33
+Version:        0.1.34
 Release:        1%{?dist}
 Summary:        Aurora branding
 
@@ -55,9 +55,6 @@ magick -background none logos/fedora-logo.svg -quality 90 -resize $((128-3*2))x3
 
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/geoclue/conf.d/ schemas%{_sysconfdir}/geoclue/conf.d/99-beacondb.conf
 install -Dpm0644 -t %{buildroot}%{_datadir}/ublue-os/homebrew/ schemas%{_datadir}/ublue-os/homebrew/*.Brewfile
-%if ((0%{?fedora} && 0%{?fedora} < 43) || 0%{?rhel})
-install -Dpm0644 -t %{buildroot}%{_datadir}/pipewire/pipewire.conf.d/ schemas%{_datadir}/pipewire/pipewire.conf.d/raop.conf
-%endif
 
 mkdir -p %{buildroot}%{_datadir}/{backgrounds,wallpapers}/
 install -Dpm0644 -t %{buildroot}%{_datadir}/backgrounds/%{vendor}/aurora-wallpaper-1/contents/images/ wallpapers/images/aurora-wallpaper-1/contents/images/15392x8616.jpg
@@ -207,7 +204,7 @@ Plymouth logo customization for Aurora
 %{_datadir}/plymouth/themes/spinner/kinoite-watermark.png
 
 %package schemas
-Version:        0.1.14
+Version:        0.1.15
 Summary:        KDE Schemas for Aurora
 
 %description schemas
@@ -216,9 +213,6 @@ Default schemas for Aurora
 %files schemas
 %{_sysconfdir}/geoclue
 %{_datadir}/ublue-os/homebrew/*.Brewfile
-%if ((0%{?fedora} && 0%{?fedora} < 43) || 0%{?rhel})
-%{_datadir}/pipewire/pipewire.conf.d/raop.conf
-%endif
 
 
 %package backgrounds

--- a/packages/aurora/schemas/usr/share/pipewire/pipewire.conf.d/raop.conf
+++ b/packages/aurora/schemas/usr/share/pipewire/pipewire.conf.d/raop.conf
@@ -1,6 +1,0 @@
-context.modules = [
-    # Use mDNS to detect and load module-raop-sink
-    { name = libpipewire-module-raop-discover
-        condition = [ { module.raop = !false } ]
-    }
-]

--- a/packages/bluefin/bluefin.spec
+++ b/packages/bluefin/bluefin.spec
@@ -2,7 +2,7 @@
 %global vendor bluefin
 
 Name:           bluefin
-Version:        0.3.31
+Version:        0.3.32
 Release:        1%{?dist}
 Summary:        Bluefin branding
 
@@ -46,9 +46,6 @@ install -Dpm0644 -t %{buildroot}%{_datadir}/glib-2.0/schemas/ schemas%{_datadir}
 install -Dpm0644 -t %{buildroot}%{_datadir}/applications/ schemas%{_datadir}/applications/*.desktop
 install -Dpm0755 schemas%{_bindir}/bluefin-bazaar-launcher %{buildroot}%{_bindir}/bluefin-bazaar-launcher
 install -Dpm0644 -t %{buildroot}%{_sysconfdir}/gnome-initial-setup/ schemas%{_sysconfdir}/gnome-initial-setup/vendor.conf
-%if ((0%{?fedora} && 0%{?fedora} < 43) || 0%{?rhel})
-install -Dpm0644 -t %{buildroot}%{_datadir}/pipewire/pipewire.conf.d/ schemas%{_datadir}/pipewire/pipewire.conf.d/raop.conf
-%endif
 
 %check
 
@@ -111,7 +108,7 @@ Plymouth logo customization for Bluefin
 
 
 %package schemas
-Version:        0.2.20
+Version:        0.2.21
 Summary:        GNOME Schemas for Bluefin
 
 %description schemas
@@ -128,9 +125,6 @@ Contains all of the DConf settings that Bluefin ships by default
 %{_datadir}/applications
 %{_datadir}/ublue-os/homebrew/*.Brewfile
 %{_bindir}/bluefin-bazaar-launcher
-%if ((0%{?fedora} && 0%{?fedora} < 43) || 0%{?rhel})
-%{_datadir}/pipewire/pipewire.conf.d/raop.conf
-%endif
 
 
 %package backgrounds

--- a/packages/bluefin/schemas/usr/share/pipewire/pipewire.conf.d/raop.conf
+++ b/packages/bluefin/schemas/usr/share/pipewire/pipewire.conf.d/raop.conf
@@ -1,6 +1,0 @@
-context.modules = [
-    # Use mDNS to detect and load module-raop-sink
-    { name = libpipewire-module-raop-discover
-        condition = [ { module.raop = !false } ]
-    }
-]


### PR DESCRIPTION
Removes the default RAOP configuration from bluefin and aurora. 

Will require one approval from each project before merging.