### PR TITLE
feat: allow sudoless bootc commands

### DIFF
--- a/packages/ublue-polkit-rules/src/etc/profile.d/bootc.sh
+++ b/packages/ublue-polkit-rules/src/etc/profile.d/bootc.sh
@@ -1,0 +1,10 @@
+if [ "$EUID" -ne 0 ]; then
+    bootc() {
+        # Check if the command is already running with sudo
+        if [ "$EUID" -eq 0 ]; then
+            /usr/bin/bootc "$@"
+        else
+            sudo /usr/bin/bootc "$@"
+        fi
+    }
+fi

--- a/packages/ublue-polkit-rules/ublue-polkit-rules.spec
+++ b/packages/ublue-polkit-rules/ublue-polkit-rules.spec
@@ -1,5 +1,5 @@
 Name:           ublue-polkit-rules
-Version:        0.1.2
+Version:        0.2.0
 Release:        1%{?dist}
 Summary:        Polkit rules for Universal Blue projects
 
@@ -20,12 +20,14 @@ Polkit Rules for Universal Blue
 
 %install
 install -Dm0644 -t %{buildroot}%{_sysconfdir}/polkit-1/rules.d/ src/%{_sysconfdir}/polkit-1/rules.d/*.rules
+install -Dm0644 -t %{buildroot}%{_sysconfdir}/profile.d/ src/%{_sysconfdir}/profile.d/*
 install -Dm0644 -t %{buildroot}%{_sysconfdir}/sudoers.d/ src/%{_sysconfdir}/sudoers.d/*
 
 %check
 
 %files
 %{_sysconfdir}/polkit-1/rules.d/*.rules
+%{_sysconfdir}/profile.d/bootc.sh
 %{_sysconfdir}/sudoers.d/001-bootc
 
 %changelog


### PR DESCRIPTION
Allowed commands that can be ran without the sudo password is configured in the sudoers.d configuration.  Currently this is just `bootc update`, `bootc upgrade` and `bootc status`.

This is not an ideal solution though - that will come when Bootc works as a daemon service.