### PR TITLE
fix(krunner-bazaar): make bazaar optional

### DIFF
--- a/packages/krunner-bazaar/krunner-bazaar.spec
+++ b/packages/krunner-bazaar/krunner-bazaar.spec
@@ -2,7 +2,7 @@
 
 Name:           krunner-bazaar
 Version:        %{majmin_ver}
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        KDE KRunner plugin for searching Flatpak applications via Bazaar
 
 License:        Apache-2.0
@@ -22,7 +22,7 @@ BuildRequires:  gettext
 Requires:       kf6-krunner
 Requires:       qt6-qtbase
 Requires:       flatpak
-Requires:       bazaar
+Suggests:       bazaar
 
 %description
 A KDE KRunner plugin that integrates with Bazaar, a GTK application for browsing


### PR DESCRIPTION
KRunner-bazaar works fine with the flatpak.
Currently there would not be a way to not have bazaar rpm as it is a hard dependency.
This opens the door for [potentially having flatpak bazaar ](https://github.com/ublue-os/aurora/issues/948)(no rpm installed) + this plugin.
Doesn't change anything for bazzite and aurora as they don't rely on this behavior anyway.