### PR TITLE
Initialize direnv in `bling.sh`

### DIFF
--- a/packages/ublue-bling/src/bling.sh
+++ b/packages/ublue-bling/src/bling.sh
@@ -32,16 +32,21 @@ HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-/home/linuxbrew/.linuxbrew}"
 ATUIN_INIT_FLAGS=${ATUIN_INIT_FLAGS:-""}
 
 if [ "$(basename $(readlink /proc/$$/exe))" = "bash" ]; then
+    # Initialize direnv before bash-preexec to avoid PROMPT_COMMAND conflicts
+    # See: https://github.com/rcaloras/bash-preexec/pull/143
+    [ "$(command -v direnv)" ] && eval "$(direnv hook bash)"
     [ -f "/etc/profile.d/bash-preexec.sh" ] && . "/etc/profile.d/bash-preexec.sh"
     [ -f "/usr/share/bash-prexec" ] && . "/usr/share/bash-prexec"
     [ -f "/usr/share/bash-prexec.sh" ] && . "/usr/share/bash-prexec.sh"
     [ -f "${HOMEBREW_PREFIX}/etc/profile.d/bash-preexec.sh" ] && . "${HOMEBREW_PREFIX}/etc/profile.d/bash-preexec.sh"
     # Initialize atuin before starship to ensure proper command history capture
-    # See: https://github.com/atuinsh/atuin/issues/2804 
+    # See: https://github.com/atuinsh/atuin/issues/2804
     [ "$(command -v atuin)" ] && eval "$(atuin init bash ${ATUIN_INIT_FLAGS})"
     [ "$(command -v starship)" ] && eval "$(starship init bash)"
     [ "$(command -v zoxide)" ] && eval "$(zoxide init bash)"
 elif [ "$(basename $(readlink /proc/$$/exe))" = "zsh" ]; then
+    # Initialize direnv before atuin to avoid PROMPT_COMMAND conflicts
+    [ "$(command -v direnv)" ] && eval "$(direnv hook zsh)"
     # Initialize atuin before starship to ensure proper command history capture
     [ "$(command -v atuin)" ] && eval "$(atuin init zsh ${ATUIN_INIT_FLAGS})"
     [ "$(command -v starship)" ] && eval "$(starship init zsh)"

--- a/packages/ublue-bling/ublue-bling.spec
+++ b/packages/ublue-bling/ublue-bling.spec
@@ -1,7 +1,7 @@
 %global debug_package %{nil}
 
 Name:           ublue-bling
-Version:        0.1.12
+Version:        0.1.13
 Release:        1%{?dist}
 Summary:        Universal Blue Bling CLI setup scripts
 


### PR DESCRIPTION
## Description
Initialize direnv in `bling.sh` for bash and zsh. direnv is already shipped in `bluefin-cli.Brewfile` but was non-functional without shell initialization.

direnv by default has built-in safeguards, so you'll still need to run `direnv allow` wherever necessary.

**A small note:** direnv is initialized **before** bash-preexec to avoid `PROMPT_COMMAND` conflicts. There's an edge case in bash-preexec where if direnv modifies `PROMPT_COMMAND` after bash-preexec sources, it breaks atuin's history capture. By initializing direnv first, we avoid this issue entirely. See:
- https://github.com/rcaloras/bash-preexec/pull/143
## Type of Change
- [x] Bug fix/new feature (direnv was installed but not configured OOTB)

## Testing Done
- Tested on running system: Yes (manually sourced modified `bling.sh`, verified direnv and atuin both work)
