### PR TITLE
fix: don't use homebrew qdbus

### DIFF
--- a/packages/ublue-brew/src/usr/lib/systemd/system/brew-upgrade.service
+++ b/packages/ublue-brew/src/usr/lib/systemd/system/brew-upgrade.service
@@ -20,3 +20,4 @@ ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink pyth
 ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink gsettings"
 ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink bash"
 ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink rpm"
+ExecStartPost=-/usr/bin/bash -c "/home/linuxbrew/.linuxbrew/bin/brew unlink qdbus"

--- a/packages/ublue-brew/ublue-brew.spec
+++ b/packages/ublue-brew/ublue-brew.spec
@@ -3,7 +3,7 @@
 %define homebrew_release homebrew-2025-11-04-01-29-53
 
 Name:           ublue-brew
-Version:        0.1.12
+Version:        0.1.13
 Release:        1%{?dist}
 Summary:        Homebrew integration for Universal Blue systems
 


### PR DESCRIPTION
I don't want to find out what breaks if homebrew qttools is on a newer version compared to system one