### PR TITLE
feat: add ublue-os-ucore-addons package

### DIFF
--- a/packages/ublue-os-ucore-addons/ublue-os-ucore-addons.spec
+++ b/packages/ublue-os-ucore-addons/ublue-os-ucore-addons.spec
@@ -9,7 +9,9 @@ URL:            https://github.com/ublue-os/packages
 BuildArch:      noarch
 Supplements:    mokutil policycoreutils
 
-Source0:        https://github.com/ublue-os/akmods/raw/refs/heads/main/certs/public_key.der
+# renovate: datasource=github-tags depName=ublue-os/akmods
+%global commit_hash 4388220452a1b71892472bf23e4082bfd477c106
+Source0: https://github.com/ublue-os/akmods/raw/%{commit_hash}/certs/public_key.der
 
 %description
 Adds the signing key for importing with mokutil to enable secure boot for kernel modules.


### PR DESCRIPTION
Adding this package to our COPR build means we can:
1. start consuming it from uCore builds instead of from `common` akmods image
1. stop building it in `common` akmods builds
3. stop building `common` akmods builds for longterm-6.12 kernel version