### PR TITLE
fix: handle fedora 43 container install failure for sanoid package

### DIFF
--- a/staging/sanoid/sanoid.spec
+++ b/staging/sanoid/sanoid.spec
@@ -6,7 +6,7 @@
 
 Name:		   sanoid
 Version:	   %{version}
-Release:	   1%{?dist}.ucore2
+Release:	   1%{?dist}.ucore3
 BuildArch:	   noarch
 Summary:	   A policy-driven snapshot management tool for ZFS file systems
 Group:		   Applications/System
@@ -104,7 +104,6 @@ echo "* * * * * root %{_sbindir}/sanoid --cron" > %{buildroot}%{_docdir}/%{name}
 %endif
 
 %post
-%post
 %{?_with_systemd:%{_bindir}/systemctl daemon-reload || :}
 
 %postun
@@ -132,6 +131,8 @@ echo "* * * * * root %{_sbindir}/sanoid --cron" > %{buildroot}%{_docdir}/%{name}
 %endif
 
 %changelog
+* Thu Nov 20 2025 Benjamin Sherman <benjamin@holyarmy.org> - 2.2.0.ucore3
+- Safely handle container installs where systemd is not running
 * Wed Oct 13 2024 John McGee <john@johnmcgee.net> - 2.2.0.ucore2
 - Correct typo in systemctl description
 * Wed Oct 09 2024 John McGee <john@johnmcgee.net> - 2.2.0.ucore1


### PR DESCRIPTION
With the newer DNF failures in scripts cause fail of transaction.

This spec is now more defensive and will not fail, only print any errors if they occur.