### PR TITLE
chore: bump kcm_ublue to 0.6.1

### DIFF
--- a/packages/kcm_ublue/kcm_ublue.spec
+++ b/packages/kcm_ublue/kcm_ublue.spec
@@ -1,4 +1,4 @@
-%global majmin_ver_kcm 0.6.0
+%global majmin_ver_kcm 0.6.1
 
 Name:           kcm_ublue
 Version:        %{majmin_ver_kcm}


### PR DESCRIPTION
## What's Changed
* fix: remove deprecated images from options by @ledif in https://github.com/ledif/kcm_ublue/pull/21


**Full Changelog**: https://github.com/ledif/kcm_ublue/compare/v0.6.0...v0.6.1