### PR TITLE
fix: alias rl to ramalama only if ramalama is available

### DIFF
--- a/packages/bluefin/schemas/etc/profile.d/ramalama.sh
+++ b/packages/bluefin/schemas/etc/profile.d/ramalama.sh
@@ -1,1 +1,4 @@
-alias rl="ramalama"
+#!/usr/bin/env bash
+if command -v ramalama > /dev/null ; then
+  alias rl="ramalama"
+fi


### PR DESCRIPTION
#599 added an alias for ramalama, but we should only set it if ramalama is available.