### PR TITLE
Fix: Force `brew shellenv` to output fish commands

### DIFF
--- a/packages/ublue-brew/src/usr/share/fish/vendor_conf.d/ublue-brew.fish
+++ b/packages/ublue-brew/src/usr/share/fish/vendor_conf.d/ublue-brew.fish
@@ -2,7 +2,7 @@
 #shellcheck disable=all
 if status --is-interactive
     if [ -d /home/linuxbrew/.linuxbrew ]
-        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv fish)"
         if test -d (brew --prefix)/share/fish/completions
             set -p fish_complete_path (brew --prefix)/share/fish/completions
         end


### PR DESCRIPTION
Brew https://github.com/Homebrew/brew/pull/21374 changed how shell is detected. Now fish is not detected in this contexts and `brew shellenv` outputs bash syntax, breaking fish initialization.

Verified by placing in `~/.config/fish/conf.d/ublue-brew.fish`