### PR TITLE
fix: downgrade plasma-setup aurora

### DIFF
--- a/staging/plasma-setup-aurora/plasma-setup.spec
+++ b/staging/plasma-setup-aurora/plasma-setup.spec
@@ -8,8 +8,8 @@
 
 Name:           plasma-setup
 # renovate: datasource=github-tags depName=KDE/plasma-setup
-Version:        6.6.4
-Release:        100.aurora
+Version:        6.6.3
+Release:        101.aurora
 Summary:        Initial setup for systems using KDE Plasma
 License:        (GPL-2.0-or-later or GPL-3.0-or-later) and GPL-2.0-or-later and GPL-3.0-or-later and (LGPL-2.0-or-later or LGPL-3.0-or-later) and (LGPL-2.1-or-later or LGPL-3.0-or-later) and LGPL-2.1-or-later and BSD-2-Clause and CC0-1.0
 URL:            https://invent.kde.org/plasma/%{name}


### PR DESCRIPTION
so it includes the path fix, plasma 6.6.4 probably won't be reaching fedora 44 until the freeze is over