### PR TITLE
Add sigstore verification for registry.access.redhat.com

### DIFF
--- a/packages/ublue-os-signing/src/usr/etc/containers/policy.json
+++ b/packages/ublue-os-signing/src/usr/etc/containers/policy.json
@@ -11,6 +11,13 @@
                     "type": "signedBy",
                     "keyType": "GPGKeys",
                     "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+                },
+                {
+                    "type": "sigstoreSigned",
+                    "keyPath": "/etc/pki/sigstore/SIGSTORE-redhat-release3",
+                    "signedIdentity": {
+                        "type": "matchRepository"
+                    }
                 }
             ],
             "registry.redhat.io": [


### PR DESCRIPTION
Bluefin LTS uses a CentOS base that does not include the gpg key for registry.access.redhat.com. It does have the sigstore key though. Here the sigstore method is added to policy.json. This addition avoids signature verification failure when trying to pull images from registry.access.redhat.com (like the ubi images) with podman on Bluefin LTS.

See https://github.com/ublue-os/bluefin-lts/issues/1292 for more context.