### PR TITLE
fix(selinux): add composefs execmem workaround package

### DIFF
--- a/packages/ublue-os-selinux-workarounds/src/selinux/ublue_os_composefs_execmem.te
+++ b/packages/ublue-os-selinux-workarounds/src/selinux/ublue_os_composefs_execmem.te
@@ -1,0 +1,13 @@
+module ublue_os_composefs_execmem 0.1;
+
+require {
+	type kernel_t;
+	class process execmem;
+}
+
+# Temporary mitigation for Linux 7.0 composefs/overlay backing-file mmap checks:
+# user-space mappings from /usr can be evaluated with backing-file credentials
+# that appear as kernel_t, causing legitimate 32-bit userspace mappings to fail.
+#
+# Tracking: https://github.com/ublue-os/akmods/issues/537
+allow kernel_t self:process execmem;

--- a/packages/ublue-os-selinux-workarounds/ublue-os-selinux-workarounds.spec
+++ b/packages/ublue-os-selinux-workarounds/ublue-os-selinux-workarounds.spec
@@ -1,0 +1,51 @@
+Name:           ublue-os-selinux-workarounds
+Vendor:         ublue-os
+Version:        0.1
+Release:        1%{?dist}
+Summary:        SELinux policy workarounds for ublue-os images
+License:        Apache-2.0
+URL:            https://github.com/ublue-os/packages
+VCS:            {{{ git_dir_vcs }}}
+Source:         {{{ git_dir_pack }}}
+
+BuildArch:      noarch
+BuildRequires:  checkpolicy
+BuildRequires:  policycoreutils
+BuildRequires:  selinux-policy
+BuildRequires:  selinux-policy-devel
+%{?selinux_requires}
+
+%global policy_module ublue_os_composefs_execmem
+
+%description
+Installs targeted SELinux policy workarounds for ublue-os images.
+
+This currently contains a narrow temporary mitigation for Linux 7.0
+composefs/overlay backing-file mmap checks causing legitimate userspace
+execmem mappings to be evaluated as kernel_t.
+
+%prep
+{{{ git_dir_setup_macro }}}
+
+%build
+checkmodule -M -m -o %{policy_module}.mod src/selinux/%{policy_module}.te
+semodule_package -o %{policy_module}.pp -m %{policy_module}.mod
+
+%install
+install -Dm0644 %{policy_module}.pp %{buildroot}%{_datadir}/selinux/packages/%{policy_module}.pp
+
+%check
+
+%post
+%selinux_modules_install %{_datadir}/selinux/packages/%{policy_module}.pp
+
+%postun
+if [ $1 -eq 0 ]; then
+    %selinux_modules_uninstall %{_datadir}/selinux/packages/%{policy_module}.pp
+fi
+
+%files
+%{_datadir}/selinux/packages/%{policy_module}.pp
+
+%changelog
+%autochangelog


### PR DESCRIPTION
Add ublue-os-selinux-workarounds with a minimal SELinux policy module allowing kernel_t self:process execmem.

This mitigates Linux 7.0 composefs/overlay backing-file mmap behavior where legitimate userspace mappings from /usr can be evaluated as kernel_t and denied under SELinux enforcing.

Only execmem is allowed; execmod is intentionally excluded because it was not required by observed Steam/Proton/NVIDIA game failures.

Relates: https://github.com/ublue-os/akmods/issues/537

This work in this commit includes code generated by AI.