### PR TITLE
Adapt TPM2 LUKS autounlock scripts for FIDO2 key enrollment

### DIFF
--- a/packages/ublue-os-just/src/recipes/15-luks.just
+++ b/packages/ublue-os-just/src/recipes/15-luks.just
@@ -1,5 +1,8 @@
 # vim: set ft=make :
 
+alias setup-luks-hwkey-unlock := setup-luks-fido-unlock
+alias remove-luks-hwkey-unlock := setup-luks-fido-unlock
+
 # Enable automatic LUKS unlock via TPM
 setup-luks-tpm-unlock:
     #!/usr/bin/bash
@@ -9,3 +12,13 @@ setup-luks-tpm-unlock:
 remove-luks-tpm-unlock:
     #!/usr/bin/bash
     sudo /usr/libexec/luks-disable-tpm2-autounlock
+
+# Enable hardware key LUKS unlock via FIDO2
+setup-luks-fido-unlock:
+    #!/usr/bin/bash
+    sudo /usr/libexec/luks-enable-fido2-autounlock
+
+# Disable hardware key LUKS unlock via FIDO2
+remove-luks-fido-unlock:
+    #!/usr/bin/bash
+    sudo /usr/libexec/luks-disable-fido2-autounlock

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -1,6 +1,6 @@
 Name:           ublue-os-just
 Vendor:         ublue-os
-Version:        0.57
+Version:        0.58
 Release:        1%{?dist}
 Summary:        ublue-os just integration
 License:        Apache-2.0
@@ -88,6 +88,9 @@ done
 %{fish_completions_dir}/ujust.fish
 
 %changelog
+* Mon Jun 08 2026 charel <charel@lotsaspaghetti.com> - 0.58
+- Add ujust shortcuts for FIDO2 LUKS enrollment (see ublue-os-luks 0.4)
+
 * Tue Jun 02 2026 Jill Fiore <contact@lumaeris.com> - 0.57-1
 - Update PyTorch Nvidia image to 26.05-py3
 - Remove obsolete Bluefin CLI and Arch AMDGPUPRO toolbox images

--- a/packages/ublue-os-luks/src/luks-disable-fido2-autounlock
+++ b/packages/ublue-os-luks/src/luks-disable-fido2-autounlock
@@ -1,5 +1,5 @@
 #!/bin/bash
-## disable auto-unlock LUKS2 encrypted root on Fedora/Silverblue/maybe others
+## disable hardware key-unlock LUKS2 encrypted root on Fedora/Silverblue/maybe others
 set -euo pipefail
 
 [ "$UID" -eq 0 ] || {
@@ -7,10 +7,10 @@ set -euo pipefail
   exit 1
 }
 
-echo "This script utilizes systemd-cryptenroll for removing tpm2 auto-unlock."
+echo "This script utilizes systemd-cryptenroll for removing fido2 auto-unlock."
 echo "You can review systemd-cryptenroll's manpage for more information."
-echo "This will modify your system and disable TPM2 auto-unlock of your LUKS partition!"
-read -p "Are you sure are good with this and want to disable TPM2 auto-unlock? (y/N): " -n 1 -r
+echo "This will modify your system and disable FIDO2 auto-unlock of your LUKS partition!"
+read -p "Are you sure are good with this and want to disable FIDO2 auto-unlock? (y/N): " -n 1 -r
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
   [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
@@ -55,30 +55,30 @@ if [[ ! -L "$CRYPT_DISK" ]]; then
 fi
 
 ## Restore the crypttab (not used in current package version)
-#cp -a /etc/crypttab /etc/crypttab.working-before-disable-tpm2
+#cp -a /etc/crypttab /etc/crypttab.working-before-disable-fido2
 #if [ -f /etc/crypttab.known-good ]; then
 #  echo "Restoring /etc/crypttab.known-good to original /etc/crypttab"
 #  mv /etc/crypttab.known-good /etc/crypttab
 #fi
 
 ## Wipe luks slot
-if cryptsetup luksDump "$CRYPT_DISK" | grep systemd-tpm2 >/dev/null; then
-  echo "Wiping systemd-tpm2 from LUKS on $CRYPT_DISK"
-  systemd-cryptenroll --wipe-slot=tpm2 "$CRYPT_DISK"
+if cryptsetup luksDump "$CRYPT_DISK" | grep systemd-fido2 >/dev/null; then
+  echo "Wiping systemd-fido2 from LUKS on $CRYPT_DISK"
+  systemd-cryptenroll --wipe-slot=fido2 "$CRYPT_DISK"
 else
-  echo "No systemd-tpm2 found in LUKS to wipe"
+  echo "No systemd-fido2 found in LUKS to wipe"
 fi
 
 ## Disable initramfs
-if rpm-ostree initramfs | grep tpm2 >/dev/null; then
-  echo "WARNING: if you configured initramfs for anything other than TPM2, this wipes that too..."
+if rpm-ostree initramfs | grep fido2 >/dev/null; then
+  echo "WARNING: if you configured initramfs for anything other than FIDO2, this wipes that too..."
   echo "here's a printout:"
   rpm-ostree initramfs
   echo
   echo "Disabling rpm-ostree initramfs..."
   rpm-ostree initramfs --disable
 else
-  echo "TPM2 is not configured in 'rpm-ostree initramfs'..."
+  echo "FIDO2 is not configured in 'rpm-ostree initramfs'..."
 fi
 
-echo "TPM2 auto-unlock disabled..."
+echo "FIDO2 auto-unlock disabled..."

--- a/packages/ublue-os-luks/src/luks-enable-fido2-autounlock
+++ b/packages/ublue-os-luks/src/luks-enable-fido2-autounlock
@@ -1,0 +1,131 @@
+#!/bin/bash
+## setup hardware key-unlock LUKS2 encrypted root on Fedora/Silverblue/maybe others
+set -eou pipefail
+
+[ "$UID" -eq 0 ] || {
+  echo "This script must be run as root."
+  exit 1
+}
+
+echo "This script uses systemd-cryptenroll to enable FIDO2 auto-unlock."
+echo "If you do not have any hardware keys (e.g. Yubikey, Nitrokey, etc) you probably want TPM2 auto-unlock instead."
+echo "You can review systemd-cryptenroll's manpage for more information."
+echo "This script will modify your system."
+echo "It will enable FIDO2 auto-unlock of your LUKS partition for your root device!"
+echo "It will enroll one or more hardware keys which are tied to your keys' FIDO2 store."
+read -p "Are you sure are good with this and want to enable FIDO2 auto-unlock? (y/N): " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
+fi
+
+## Inspect Kernel Cmdline for rd.luks.uuid
+RD_LUKS_UUID="$(xargs -n1 -a /proc/cmdline | grep rd.luks.uuid | cut -d = -f 2)"
+
+# Check to make sure cmdline rd.luks.uuid exists
+if [[ -z ${RD_LUKS_UUID:-} ]]; then
+  printf "LUKS device not defined on Kernel Commandline.\n"
+  printf "This is not supported by this script.\n"
+  printf "Exiting...\n"
+  exit 1
+fi
+
+# Check to make sure that the specified cmdline uuid exists.
+if ! grep -q "${RD_LUKS_UUID}" <<<"$(lsblk)"; then
+  printf "LUKS device not listed in block devices.\n"
+  printf "Exiting...\n"
+  exit 1
+fi
+
+# Cut off the luks-
+LUKS_PREFIX="luks-"
+if grep -q ^${LUKS_PREFIX} <<<"${RD_LUKS_UUID}"; then
+  DISK_UUID=${RD_LUKS_UUID#"$LUKS_PREFIX"}
+else
+  echo "LUKS UUID format mismatch."
+  echo "Exiting..."
+  exit 1
+fi
+
+SET_PIN_ARG=""
+read -p "Would you like to require the keys' FIDO2 PIN? (y/N): " -n 1 -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  SET_PIN_ARG=" --fido2-with-client-pin=no "
+fi
+
+# Specify Crypt Disk by-uuid
+CRYPT_DISK="/dev/disk/by-uuid/$DISK_UUID"
+
+# Check to make sure crypt disk exists
+if [[ ! -L "$CRYPT_DISK" ]]; then
+  printf "LUKS device not listed in block devices.\n"
+  printf "Exiting...\n"
+  exit 1
+fi
+
+LUKS_DUMP="$(cryptsetup luksDump "$CRYPT_DISK")"
+if echo "$LUKS_DUMP" | grep systemd-tpm2 >/dev/null; then
+  KEYSLOT=$(cryptsetup luksDump "$CRYPT_DISK" | sed -n '/systemd-tpm2$/,/Keyslot:/p' | grep Keyslot | awk '{print $2}')
+  echo "TPM2 already present in LUKS keyslot $KEYSLOT of $CRYPT_DISK."
+  echo "You may enroll FIDO2 keys alongside TPM2 (e.g. as a backup), but auto-unlock is already configured without FIDO2 keys!"
+  echo "If you'd like to use hardware keys for auto-unlock, consider unenrolling the TPM2 slot first."
+  read -p "Proceed with FIDO2 enrollment? (y/N): " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    echo
+    echo "Either clear the existing TPM2 keyslot before retrying, else choose 'y' next time."
+    echo "Exiting..."
+    [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1
+  fi
+fi
+if echo "$LUKS_DUMP" | grep systemd-fido2 >/dev/null; then
+  ## Need to format with commas because it's usually encouraged to enroll multiple FIDO2 keys as backups, thus there'd likely be multiple slots
+  # TODO: I'm sure there's a way to remove the trailing comma without resorting to a pipe to sed but I'm not an awk wizard (yet)
+  KEYSLOT=$(cryptsetup luksDump /dev/nvme0n1p3 | sed -n '/systemd-fido2$/,/Keyslot:/p' | grep Keyslot | awk '{printf "%s,", $2}' | sed -E 's/,$/\n/')
+  echo "FIDO2 already present in LUKS keyslot(s) $KEYSLOT of $CRYPT_DISK."
+  read -p "Wipe it and re-enroll? (reply 'N' if enrolling additional backup keys!) (y/N): " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo
+    systemd-cryptenroll --wipe-slot=fido2 "$CRYPT_DISK"
+  fi
+fi
+
+## Run crypt enroll, potentially multiple times if user has multiple keys
+ENROLL_LOOP=0
+while [[ $ENROLL_LOOP -eq 0 ]]; do
+  while [[ "$(systemd-cryptenroll --fido2-device=list &>/dev/stdout)" =~ ^No\ FIDO2.* ]]; do
+    echo "Waiting for a FIDO2 device (CTRL+C to cancel)..."
+    sleep 5
+  done
+
+  echo "Enrolling FIDO2 unlock requires your existing LUKS2 unlock password"
+  systemd-cryptenroll --fido2-device=auto $SET_PIN_ARG "$CRYPT_DISK"
+  read -p "Enroll another FIDO2 key? (y/N): " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    ENROLL_LOOP=1
+  fi
+done
+
+if lsinitrd 2>&1 | grep -q fido2 >/dev/null; then
+  ## add fido2 to initramfs
+  if rpm-ostree initramfs | grep fido2 >/dev/null; then
+    echo "FIDO2 already present in rpm-ostree initramfs config."
+    rpm-ostree initramfs
+    echo "Re-running initramfs to pickup changes above."
+  fi
+  rpm-ostree initramfs --enable --arg=--force-add --arg=fido2
+else
+  ## initramfs already containts fido2
+  echo "FIDO2 already present in initramfs."
+fi
+
+## Now reboot
+echo
+echo "FIDO2 LUKS auto-unlock configured. Reboot now."
+
+# References:
+#  https://www.reddit.com/r/Fedora/comments/uo4ufq/any_way_to_get_systemdcryptenroll_working_on/
+#  https://0pointer.net/blog/unlocking-luks2-volumes-with-tpm2-fido2-pkcs11-security-hardware-on-systemd-248.html

--- a/packages/ublue-os-luks/ublue-os-luks.spec
+++ b/packages/ublue-os-luks/ublue-os-luks.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-luks
 Vendor:         ublue-os
-Version:        0.3
-Release:        1%{?dist}
+Version:        0.4
+Release:        4%{?dist}
 Summary:        ublue-os scripts for simplified LUKS usage
 License:        Apache-2.0
 URL:            https://github.com/ublue-os/packages
@@ -21,6 +21,8 @@ Adds scripts and dracut config to simplify LUKS autounlock
 %install
 install -Dm755 -t %{buildroot}%{_libexecdir}/ src/luks-disable-tpm2-autounlock
 install -Dm755 -t %{buildroot}%{_libexecdir}/ src/luks-enable-tpm2-autounlock
+install -Dm755 -t %{buildroot}%{_libexecdir}/ src/luks-disable-fido2-autounlock
+install -Dm755 -t %{buildroot}%{_libexecdir}/ src/luks-enable-fido2-autounlock
 install -Dm644 -t %{buildroot}%{_exec_prefix}/lib/dracut/dracut.conf.d src/90-ublue-luks.conf
 
 %check
@@ -28,9 +30,14 @@ install -Dm644 -t %{buildroot}%{_exec_prefix}/lib/dracut/dracut.conf.d src/90-ub
 %files
 %{_libexecdir}/luks-disable-tpm2-autounlock
 %{_libexecdir}/luks-enable-tpm2-autounlock
+%{_libexecdir}/luks-disable-fido2-autounlock
+%{_libexecdir}/luks-enable-fido2-autounlock
 %{_exec_prefix}/lib/dracut/dracut.conf.d/90-ublue-luks.conf
 
 %changelog
+* Mon Jun 08 2026 charel <charel@lotsaspaghetti.com> - 0.4
+- Adapt TPM2 scripts for FIDO2 key enrollment
+
 * Thu Jul 04 2024 m2Giles <69128853+m2Giles@users.noreply.github.com> - 0.3
 - Rewrite enable script to fail out if disk is not found
 - LUKs disk is determined from kernel commandline instead of /etc/crypttab

--- a/packages/ublue-os-luks/ublue-os-luks.spec
+++ b/packages/ublue-os-luks/ublue-os-luks.spec
@@ -37,6 +37,7 @@ install -Dm644 -t %{buildroot}%{_exec_prefix}/lib/dracut/dracut.conf.d src/90-ub
 %changelog
 * Mon Jun 08 2026 charel <charel@lotsaspaghetti.com> - 0.4
 - Adapt TPM2 scripts for FIDO2 key enrollment
+- Comment-out crypttab restore in TPM disable script since initramfs is used instead
 
 * Thu Jul 04 2024 m2Giles <69128853+m2Giles@users.noreply.github.com> - 0.3
 - Rewrite enable script to fail out if disk is not found


### PR DESCRIPTION
The use of FIDO2 devices such as Yubikeys to decrypt the root LUKS partition is a more secure alternative to TPM2 on CPUs vulnerable to faulTPM, and is perfectly usable on PC handhelds without requiring an external keyboard if `--fido2-with-client-pin=no` is set at key enrollment. Since the `systemd-cryptenroll` utility supports both TPM2 and FIDO2, I used the already-existing TPM2 scripts as a base for easily enrolling one or more FIDO2 keys to a system's encrypted root.

I'm new to RPM packaging so please let me know if I messed anything up in that regard! 😳 It's just adding two shell scripts and modifying a justfile but still.