### PR TITLE
fix: only chmod battery threshold files when they exist

### DIFF
--- a/packages/ublue-os-udev-rules/src/udev-rules.d/99-thinkpad-thresholds-udev.rules
+++ b/packages/ublue-os-udev-rules/src/udev-rules.d/99-thinkpad-thresholds-udev.rules
@@ -1,7 +1,7 @@
 # Change the permissions of the battery threshold attributes so that they can be modified by ordinary users
 # See https://gitlab.com/marcosdalvarez/thinkpad-battery-threshold-extension
 
-ACTION=="add|change", KERNEL=="BAT[0-1]", GROUP="wheel" , SUBSYSTEM=="power_supply", TEST{0002}!="/sys%p/charge_control_start_threshold", RUN+="/bin/chmod 666 /sys%p/charge_control_start_threshold"
-ACTION=="add|change", KERNEL=="BAT[0-1]", GROUP="wheel" , SUBSYSTEM=="power_supply", TEST{0002}!="/sys%p/charge_control_end_threshold", RUN+="/bin/chmod 666 /sys%p/charge_control_end_threshold"
-ACTION=="add|change", KERNEL=="BAT[0-1]", GROUP="wheel" , SUBSYSTEM=="power_supply", TEST{0002}!="/sys%p/charge_start_threshold", RUN+="/bin/chmod 666 /sys%p/charge_start_threshold"
-ACTION=="add|change", KERNEL=="BAT[0-1]", GROUP="wheel" , SUBSYSTEM=="power_supply", TEST{0002}!="/sys%p/charge_stop_threshold", RUN+="/bin/chmod 666 /sys%p/charge_stop_threshold"
+ACTION=="add|change", KERNEL=="BAT[0-1]", GROUP="wheel" , SUBSYSTEM=="power_supply", TEST=="/sys%p/charge_control_start_threshold", TEST{0002}!="/sys%p/charge_control_start_threshold", RUN+="/bin/chmod 666 /sys%p/charge_control_start_threshold"
+ACTION=="add|change", KERNEL=="BAT[0-1]", GROUP="wheel" , SUBSYSTEM=="power_supply", TEST=="/sys%p/charge_control_end_threshold", TEST{0002}!="/sys%p/charge_control_end_threshold", RUN+="/bin/chmod 666 /sys%p/charge_control_end_threshold"
+ACTION=="add|change", KERNEL=="BAT[0-1]", GROUP="wheel" , SUBSYSTEM=="power_supply", TEST=="/sys%p/charge_start_threshold", TEST{0002}!="/sys%p/charge_start_threshold", RUN+="/bin/chmod 666 /sys%p/charge_start_threshold"
+ACTION=="add|change", KERNEL=="BAT[0-1]", GROUP="wheel" , SUBSYSTEM=="power_supply", TEST=="/sys%p/charge_stop_threshold", TEST{0002}!="/sys%p/charge_stop_threshold", RUN+="/bin/chmod 666 /sys%p/charge_stop_threshold"


### PR DESCRIPTION
The `99-thinkpad-thresholds-udev.rules` rules only checked the permission bits
of the charge threshold attributes (`TEST{0002}!=`), not whether the attribute
files exist. On hardware that does not expose these attributes (e.g. Framework
laptops), the negated permission test is always true, so the rule keeps running
`chmod 666` against non-existent paths on every `add|change` event. The chmod
fails with exit code 1 and the rule fires in a tight loop, spamming the journal
and pinning a CPU core (reported overheating).

This adds an existence `TEST==` guard before the permission check on each line,
so the chmod only runs when the attribute actually exists. On Thinkpads where
the attributes are present, both conditions still match and behaviour is
unchanged.

related to this issue: https://github.com/ublue-os/packages/issues/1256