### PR TITLE
fix: finally fix ujust autocomplete

### DIFF
--- a/packages/ublue-os-just/src/share-fish-vendor/ujust.fish
+++ b/packages/ublue-os-just/src/share-fish-vendor/ujust.fish
@@ -1,0 +1,1 @@
+alias ujust='just --justfile "/usr/share/ublue-os/justfile"'

--- a/packages/ublue-os-just/src/share-zsh-sitevendor/_ujust
+++ b/packages/ublue-os-just/src/share-zsh-sitevendor/_ujust
@@ -1,0 +1,12 @@
+#compdef ujust
+
+_ujust() {
+  # Hardcode justfile arguments into the completion context
+  words=(just --justfile "/usr/share/ublue-os/justfile" "${words[@]:1}")
+  (( CURRENT += 2 ))
+  
+  # Delegate to just's native completion function
+  _just
+}
+
+_ujust "$@"

--- a/packages/ublue-os-just/src/ujust
+++ b/packages/ublue-os-just/src/ujust
@@ -1,3 +1,3 @@
 #!/usr/bin/bash
 
-/usr/bin/just --justfile /usr/share/ublue-os/justfile "${@}"
+JUST_JUSTFILE="/usr/share/ublue-os/justfile" /usr/bin/just "${@}"

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -63,13 +63,10 @@ mkdir -p %{buildroot}%{bash_completions_dir} %{buildroot}%{zsh_completions_dir} 
 JUST_COMPLETE=bash just | sed -E 's/just/ujust/g' >> %{buildroot}%{bash_completions_dir}/ujust
 
 # Setup ujust zsh completion
-install -Dpm0644 ./share-zsh-sitevendor/_ujust %{buildroot}%{zsh_completions_dir}/_ujust
+install -Dpm0644 ./src/share-zsh-sitevendor/_ujust %{buildroot}%{zsh_completions_dir}/_ujust
 
 # Setup ujust fish completion (alias to just --justfile "/usr/share/ublue-os/justfile")
-install -Dpm0644 ./share-fish-vendor/ujust.fish %{buildroot}%{_datadir}/fish/vendor_conf.d/ujust.fish
-
-# zsh and fish completion works 
-%post
+install -Dpm0644 ./src/share-fish-vendor/ujust.fish %{buildroot}%{_datadir}/fish/vendor_conf.d/ujust.fish
 
 %check
 find %{buildroot}/%{_datadir}/%{VENDOR}/%{sub_name}/ -type f -name "*.just" | while read -r file; do

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -85,7 +85,7 @@ done
 %{_sysconfdir}/distrobox/*.ini
 %{bash_completions_dir}/ujust
 %{zsh_completions_dir}/_ujust
-%{fish_completions_dir}/ujust.fish
+%{_datadir}/fish/vendor_conf.d/ujust.fish
 
 %changelog
 * Tue Jun 02 2026 Jill Fiore <contact@lumaeris.com> - 0.57-1

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -1,7 +1,7 @@
 Name:           ublue-os-just
 Vendor:         ublue-os
 Version:        0.57
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        ublue-os just integration
 License:        Apache-2.0
 URL:            https://github.com/ublue-os/packages

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -60,13 +60,16 @@ install -Dpm0644 ./src/etc-distrobox/* %{buildroot}/%{_sysconfdir}/distrobox/
 mkdir -p %{buildroot}%{bash_completions_dir} %{buildroot}%{zsh_completions_dir} %{buildroot}%{fish_completions_dir}
 
 # Generate ujust bash completion
-JUST_COMPLETE=bash just | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{bash_completions_dir}/ujust
+echo 'JUST_JUSTFILE="/usr/share/ublue-os/justfile"' > %{buildroot}%{bash_completions_dir}/ujust
+JUST_COMPLETE=bash just | sed -E 's/_just/_ujust/g' >> %{buildroot}%{bash_completions_dir}/ujust
 
 # Generate ujust zsh completion
-JUST_COMPLETE=zsh just | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{zsh_completions_dir}/_ujust
+echo 'JUST_JUSTFILE="/usr/share/ublue-os/justfile"' > %{buildroot}%{zsh_completions_dir}/_ujust
+JUST_COMPLETE=zsh just | sed -E 's/_just/_ujust/g' >> %{buildroot}%{zsh_completions_dir}/_ujust
 
 # Generate ujust fish completion
-JUST_COMPLETE=fish just | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{fish_completions_dir}/ujust.fish
+echo 'JUST_JUSTFILE="/usr/share/ublue-os/justfile"' > %{buildroot}%{fish_completions_dir}/ujust.fish
+JUST_COMPLETE=fish just | sed -E 's/_just/_ujust/g' >> %{buildroot}%{fish_completions_dir}/ujust.fish
 
 %check
 find %{buildroot}/%{_datadir}/%{VENDOR}/%{sub_name}/ -type f -name "*.just" | while read -r file; do

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -60,16 +60,13 @@ install -Dpm0644 ./src/etc-distrobox/* %{buildroot}/%{_sysconfdir}/distrobox/
 mkdir -p %{buildroot}%{bash_completions_dir} %{buildroot}%{zsh_completions_dir} %{buildroot}%{fish_completions_dir}
 
 # Generate ujust bash completion
-echo 'JUST_JUSTFILE="/usr/share/ublue-os/justfile"' > %{buildroot}%{bash_completions_dir}/ujust
-JUST_COMPLETE=bash just | sed -E 's/_just/_ujust/g' >> %{buildroot}%{bash_completions_dir}/ujust
+JUST_COMPLETE=bash just | sed -E 's/just/ujust/g' >> %{buildroot}%{bash_completions_dir}/ujust
 
 # Generate ujust zsh completion
-echo 'JUST_JUSTFILE="/usr/share/ublue-os/justfile"' > %{buildroot}%{zsh_completions_dir}/_ujust
-JUST_COMPLETE=zsh just | sed -E 's/_just/_ujust/g' >> %{buildroot}%{zsh_completions_dir}/_ujust
+JUST_COMPLETE=zsh just | sed -E 's/just/ujust/g' >> %{buildroot}%{zsh_completions_dir}/_ujust
 
 # Generate ujust fish completion
-echo 'JUST_JUSTFILE="/usr/share/ublue-os/justfile"' > %{buildroot}%{fish_completions_dir}/ujust.fish
-JUST_COMPLETE=fish just | sed -E 's/_just/_ujust/g' >> %{buildroot}%{fish_completions_dir}/ujust.fish
+JUST_COMPLETE=fish just | sed -E 's/just/ujust/g' >> %{buildroot}%{fish_completions_dir}/ujust.fish
 
 %check
 find %{buildroot}/%{_datadir}/%{VENDOR}/%{sub_name}/ -type f -name "*.just" | while read -r file; do

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -60,13 +60,13 @@ install -Dpm0644 ./src/etc-distrobox/* %{buildroot}/%{_sysconfdir}/distrobox/
 mkdir -p %{buildroot}%{bash_completions_dir} %{buildroot}%{zsh_completions_dir} %{buildroot}%{fish_completions_dir}
 
 # Generate ujust bash completion
-just --completions bash | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{bash_completions_dir}/ujust
+JUST_COMPLETE=bash just | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{bash_completions_dir}/ujust
 
 # Generate ujust zsh completion
-just --completions zsh | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{zsh_completions_dir}/_ujust
+JUST_COMPLETE=zsh just | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{zsh_completions_dir}/_ujust
 
 # Generate ujust fish completion
-just --completions fish | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{fish_completions_dir}/ujust.fish
+JUST_COMPLETE=fish just | sed -E 's/([\(_" ])just/\1ujust/g' > %{buildroot}%{fish_completions_dir}/ujust.fish
 
 %check
 find %{buildroot}/%{_datadir}/%{VENDOR}/%{sub_name}/ -type f -name "*.just" | while read -r file; do

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -62,11 +62,11 @@ mkdir -p %{buildroot}%{bash_completions_dir} %{buildroot}%{zsh_completions_dir} 
 # Generate ujust bash completion
 JUST_COMPLETE=bash just | sed -E 's/just/ujust/g' >> %{buildroot}%{bash_completions_dir}/ujust
 
-# Generate ujust zsh completion
-JUST_COMPLETE=zsh just | sed -E 's/just/ujust/g' >> %{buildroot}%{zsh_completions_dir}/_ujust
+# Setup ujust zsh completion
+install -Dpm0644 ./share-zsh-sitevendor/_ujust %{buildroot}%{zsh_completions_dir}/_ujust
 
 # Setup ujust fish completion (alias to just --justfile "/usr/share/ublue-os/justfile")
-install -Dpm0755 ./share-fish-vendor/ujust.fish %{buildroot}%{_datadir}/fish/vendor_conf.d/ujust.fish
+install -Dpm0644 ./share-fish-vendor/ujust.fish %{buildroot}%{_datadir}/fish/vendor_conf.d/ujust.fish
 
 # zsh and fish completion works 
 %post

--- a/packages/ublue-os-just/ublue-os-just.spec
+++ b/packages/ublue-os-just/ublue-os-just.spec
@@ -65,8 +65,11 @@ JUST_COMPLETE=bash just | sed -E 's/just/ujust/g' >> %{buildroot}%{bash_completi
 # Generate ujust zsh completion
 JUST_COMPLETE=zsh just | sed -E 's/just/ujust/g' >> %{buildroot}%{zsh_completions_dir}/_ujust
 
-# Generate ujust fish completion
-JUST_COMPLETE=fish just | sed -E 's/just/ujust/g' >> %{buildroot}%{fish_completions_dir}/ujust.fish
+# Setup ujust fish completion (alias to just --justfile "/usr/share/ublue-os/justfile")
+install -Dpm0755 ./share-fish-vendor/ujust.fish %{buildroot}%{_datadir}/fish/vendor_conf.d/ujust.fish
+
+# zsh and fish completion works 
+%post
 
 %check
 find %{buildroot}/%{_datadir}/%{VENDOR}/%{sub_name}/ -type f -name "*.just" | while read -r file; do


### PR DESCRIPTION
amazing what having freetime does
<img width="854" height="75" alt="image" src="https://github.com/user-attachments/assets/74a701fb-1eba-4f85-a3dd-e98c691a2055" />

Final solution for the new just completion engine ended up being;
For `bash` we have to change the script to set `JUST_JUSTFILE` while having an autocomplete script where `just` is substituted to `ujust`.

For `fish` the only method i found to get the completions working properly was to alias `ujust` to `just --justfile "/usr/share/ublue-os/justfile"`

now for zsh i had to write a custom compdef that hardcodes in `--justfile "/usr/share/ublue-os/justfile"` and passes it to the completion definitions for `just`, i do not want to go into how long i spent on this stupid compdef...
