### PR TITLE
Add the gnome-rounded-blur package

### DIFF
--- a/staging/gnome-rounded-blur/gnome-rounded-blur.spec
+++ b/staging/gnome-rounded-blur/gnome-rounded-blur.spec
@@ -1,0 +1,66 @@
+Name:           gnome-rounded-blur
+# renovate: datasource=github-tags depName=kancko/gnome-rounded-blur
+Version:        1.0.1 
+Release:        1%{?dist}
+Summary:        Library providing Blur.Blur Effect with corner radius support
+
+License:        GPL-3.0-or-later
+URL:            https://github.com/kancko/gnome-rounded-blur 
+Source0:        %{url}/archive/v%{version}.tar.gz
+#This patch allows building on fedora 45/rawhide
+#https://github.com/kancko/gnome-rounded-blur/pull/4
+Patch0:         relax-dependency.patch
+
+BuildRequires:  meson
+BuildRequires:  gcc
+BuildRequires:  glib2-devel
+BuildRequires:  mutter-devel
+Requires:       mutter >= 50
+Recommends:     gnome-shell-extension-blur-my-shell
+
+%description
+A standalone library providing Blur.Blur Effect with corner radius support
+for GNOME Shell extensions. It's basically just copy of ShellBlur Effect with
+a corner mask and a different namespace (Blur).
+
+
+%package devel
+Summary:  Libraries and header files for file development
+Requires: gnome-rounded-blur%{?_isa} = %{version}-%{release}
+
+%description devel
+The gnome-rounded-blur-devel package contains the
+header files necessary for developing programs 
+using gnome-rounded-blur-devel.
+
+# Upstream hard-coded the build process on libmutter-18 (Gnome 50). As such, I have confirmed it works on Gnome 51, and am modifying the dependency check to allow libmutter-51
+%prep
+%autosetup
+%conf
+%meson
+
+%build
+%meson_build
+
+%install
+%meson_install
+
+
+%files
+%{_libdir}/girepository-1.0/Blur-1.0.typelib
+%{_libdir}/libblur-effect-1.0.so.1
+%{_libdir}/libblur-effect-1.0.so.1.0.0
+%license LICENSE
+%doc README.md
+
+%files devel
+%{_includedir}/blur-effect-1.0/rounded-blur-effect.h
+%dir %{_includedir}/blur-effect-1.0
+%{_libdir}/libblur-effect-1.0.so
+%{_libdir}/pkgconfig/blur-effect-1.0.pc
+%dir %{_datadir}/gir-1.0
+%{_datadir}/gir-1.0/Blur-1.0.gir
+%doc README.md
+
+%changelog
+%autochangelog

--- a/staging/gnome-rounded-blur/relax-dependency.patch
+++ b/staging/gnome-rounded-blur/relax-dependency.patch
@@ -1,0 +1,54 @@
+--- meson.build.orig	2026-08-07 21:20:51.674685436 +0200
++++ meson.build	2026-08-07 21:55:23.173022181 +0200
+@@ -21,23 +21,39 @@
+ includedir = join_paths(prefix, get_option('includedir'))
+ datadir = join_paths(prefix, get_option('datadir'))
+ 
+-mutter_api_version = '18'
++mutter_api_versions = ['51', '18']
+ mutter_req = '>= 50.0'
+ 
+-clutter_pc = 'mutter-clutter-' + mutter_api_version
+-cogl_pc = 'mutter-cogl-' + mutter_api_version
+-
+ # Dependencies
++mutter_api_version = ''
++clutter_dep = disabler()
++cogl_dep = disabler()
++libmutter_dep = disabler()
++
++foreach ver : mutter_api_versions
++  clutter_pc = 'mutter-clutter-' + ver
++  cogl_pc = 'mutter-cogl-' + ver
++  libmutter_pc = 'libmutter-' + ver
++
++  clutter_try = dependency(clutter_pc, version: mutter_req, required: false)
++  cogl_try = dependency(cogl_pc, version: mutter_req, required: false)
++  libmutter_try = dependency(libmutter_pc, required: false)
++
++  if clutter_try.found() and cogl_try.found() and libmutter_try.found()
++    mutter_api_version = ver
++    clutter_dep = clutter_try
++    cogl_dep = cogl_try
++    libmutter_dep = libmutter_try
++    break
++  endif
++endforeach
++
++if mutter_api_version == ''
++  error('The only supported versions of the mutter api are: ' + ', '.join(mutter_api_versions))
++endif
++
+ glib_dep = dependency('glib-2.0', version: '>= 2.66')
+ gobject_dep = dependency('gobject-2.0', version: '>= 2.66')
+-clutter_dep = dependency(clutter_pc, version: mutter_req,
+-  required: false,
+-)
+-
+-cogl_dep = dependency(cogl_pc, version: mutter_req,
+-  required: false,
+-)
+-libmutter_dep = dependency('libmutter-18')
+ 
+ # Required dependencies
+ deps = [


### PR DESCRIPTION
The goal of this package is to fix ublue-os/bazzite#5070, as well as ublue-os/bluefin#4815.

Basically, the Blur my Shell extension, which is shipped by default in both bluefin and bazzite-gnome, has chosen to use a [C library](https://github.com/kancko/gnome-rounded-blur) which allows it to implement dynamic corner blur. While the actual features that utilise this have been disabled by default for now, this package would allow that functionality.

This MR includes a specfile, as well as a patch, which is necessary, as the upstream is hardcoded to build on Gnome 50. I have submitted the patch [upstream](https://github.com/kancko/gnome-rounded-blur/pull/4).

Reference copr :
https://copr.fedorainfracloud.org/coprs/aneagle/gnome-rounded-blur/

Checks :

- Follows the fedora packaging guidlines (ran fedora-review)
- Renovate works
- The library is tested, and working, on f44/rawhide x86_64, and f44 aarch64