### PR TITLE
fix: patch ostree to fix flatpak updates with deltas

### DIFF
--- a/staging/ostree/3645.patch
+++ b/staging/ostree/3645.patch
@@ -1,0 +1,417 @@
+From 3cac5a941b10c317c2fd3c953d2fe4905ff39e31 Mon Sep 17 00:00:00 2001
+From: Colin Walters <walters@verbum.org>
+Date: Mon, 17 Aug 2026 19:29:35 -0400
+Subject: [PATCH 1/2] static-delta: Drop unreliable usize-based margin
+ heuristic
+
+The per-object margin formula added in the previous commit tries to
+bound the gap between a delta part's declared usize (sum of
+reconstructed object sizes) and its actual decompressed payload size
+by scaling with the number of objects in the part.  That's the wrong
+axis: the biggest source of that gap is the bsdiff patch stream for
+bsdiff'd objects, which scales with object *content* size, not object
+*count*.  A part with just one or two large bsdiff'd objects (e.g. a
+big shared library that changed significantly between releases) blows
+right past the margin, causing legitimate deltas to be rejected at
+apply time.  This is the root cause of
+https://github.com/ostreedev/ostree/issues/3635.
+
+Just drop it, we'll work to add a more reliable limit later.
+
+Assisted-by: https://github.com/cgwalters/cgwalters#llms
+Signed-off-by: Colin Walters <walters@verbum.org>
+---
+ src/libostree/ostree-repo-pull.c              | 15 ++--
+ src/libostree/ostree-repo-static-delta-core.c | 63 ++-------------
+ .../ostree-repo-static-delta-private.h        | 79 +++----------------
+ 3 files changed, 25 insertions(+), 132 deletions(-)
+
+diff --git a/src/libostree/ostree-repo-pull.c b/src/libostree/ostree-repo-pull.c
+index 5f729e68f7..63277f2aba 100644
+--- a/src/libostree/ostree-repo-pull.c
++++ b/src/libostree/ostree-repo-pull.c
+@@ -1270,12 +1270,9 @@ static_deltapart_fetch_on_complete (GObject *object, GAsyncResult *result, gpoin
+   /* Transfer ownership of the fd */
+   in = g_unix_input_stream_new (g_steal_fd (&tmpf.fd), TRUE);
+ 
+-  guint32 n_objects
+-      = (guint32)(g_variant_get_size (fetch_data->objects) / OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN);
+   /* TODO - make async */
+-  if (!_ostree_static_delta_part_open (in, NULL, 0, fetch_data->expected_checksum,
+-                                       fetch_data->usize, n_objects, &part, pull_data->cancellable,
+-                                       error))
++  if (!_ostree_static_delta_part_open (in, NULL, 0, fetch_data->expected_checksum, &part,
++                                       pull_data->cancellable, error))
+     goto out;
+ 
+   _ostree_static_delta_part_execute_async (pull_data->repo, fetch_data->objects, part,
+@@ -2214,12 +2211,10 @@ process_one_static_delta (OtPullData *pull_data, const char *from_revision, cons
+           g_autoptr (GInputStream) memin = g_memory_input_stream_new_from_bytes (inline_part_bytes);
+           g_autoptr (GVariant) inline_delta_part = NULL;
+ 
+-          guint32 n_objects
+-              = (guint32)(g_variant_get_size (objects) / OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN);
+           /* For inline parts we are relying on per-commit GPG, so don't bother checksumming. */
+-          if (!_ostree_static_delta_part_open (
+-                  memin, inline_part_bytes, OSTREE_STATIC_DELTA_OPEN_FLAGS_SKIP_CHECKSUM, NULL,
+-                  usize, n_objects, &inline_delta_part, cancellable, error))
++          if (!_ostree_static_delta_part_open (memin, inline_part_bytes,
++                                               OSTREE_STATIC_DELTA_OPEN_FLAGS_SKIP_CHECKSUM, NULL,
++                                               &inline_delta_part, cancellable, error))
+             {
+               fetch_static_delta_data_free (fetch_data);
+               return FALSE;
+diff --git a/src/libostree/ostree-repo-static-delta-core.c b/src/libostree/ostree-repo-static-delta-core.c
+index fee27de018..abcca819a3 100644
+--- a/src/libostree/ostree-repo-static-delta-core.c
++++ b/src/libostree/ostree-repo-static-delta-core.c
+@@ -585,10 +585,8 @@ ostree_repo_static_delta_execute_offline_with_signature (OstreeRepo *self, GFile
+            */
+           delta_open_flags |= OSTREE_STATIC_DELTA_OPEN_FLAGS_SKIP_CHECKSUM;
+ 
+-          guint32 n_objects
+-              = (guint32)(g_variant_get_size (objects) / OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN);
+           if (!_ostree_static_delta_part_open (part_in, inline_part_bytes, delta_open_flags, NULL,
+-                                               usize, n_objects, &part, cancellable, error))
++                                               &part, cancellable, error))
+             return FALSE;
+         }
+       else
+@@ -600,10 +598,8 @@ ostree_repo_static_delta_execute_offline_with_signature (OstreeRepo *self, GFile
+ 
+           part_in = g_unix_input_stream_new (part_fd, FALSE);
+ 
+-          guint32 n_objects
+-              = (guint32)(g_variant_get_size (objects) / OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN);
+-          if (!_ostree_static_delta_part_open (part_in, NULL, delta_open_flags, checksum, usize,
+-                                               n_objects, &part, cancellable, error))
++          if (!_ostree_static_delta_part_open (part_in, NULL, delta_open_flags, checksum, &part,
++                                               cancellable, error))
+             return FALSE;
+         }
+ 
+@@ -637,64 +633,19 @@ ostree_repo_static_delta_execute_offline (OstreeRepo *self, GFile *dir_or_file,
+       self, dir_or_file, NULL, skip_validation, cancellable, error);
+ }
+ 
+-/* Compute how much larger than the declared usize a part's decompressed
+- * payload is allowed to be.  See the constants in
+- * ostree-repo-static-delta-private.h for the derivation of each term;
+- * all arithmetic saturates to G_MAXUINT64 on overflow rather than
+- * wrapping, since expected_usize comes from the (not yet fully
+- * validated) delta part header.
+- */
+-static guint64
+-_ostree_static_delta_compute_part_margin (guint64 expected_usize, guint32 expected_n_objects)
+-{
+-  guint64 margin = OSTREE_STATIC_DELTA_PART_FIXED_OVERHEAD_BYTES;
+-
+-  guint64 per_object_overhead;
+-  if (!g_uint64_checked_mul (&per_object_overhead, (guint64)expected_n_objects,
+-                             OSTREE_STATIC_DELTA_PART_OP_OVERHEAD_PER_OBJECT_BYTES
+-                                 + OSTREE_STATIC_DELTA_PART_XATTR_ALLOWANCE_PER_OBJECT_BYTES)
+-      || !g_uint64_checked_add (&margin, margin, per_object_overhead))
+-    return G_MAXUINT64;
+-
+-  const guint64 rollsum_overhead
+-      = expected_usize / OSTREE_STATIC_DELTA_PART_ROLLSUM_OVERHEAD_DIVISOR;
+-  if (!g_uint64_checked_add (&margin, margin, rollsum_overhead))
+-    return G_MAXUINT64;
+-
+-  return margin;
+-}
+-
+ gboolean
+ _ostree_static_delta_part_open (GInputStream *part_in, GBytes *inline_part_bytes,
+                                 OstreeStaticDeltaOpenFlags flags, const char *expected_checksum,
+-                                guint64 expected_usize, guint32 expected_n_objects,
+                                 GVariant **out_part, GCancellable *cancellable, GError **error)
+ {
+   const gboolean trusted = (flags & OSTREE_STATIC_DELTA_OPEN_FLAGS_VARIANT_TRUSTED) > 0;
+   const gboolean skip_checksum = (flags & OSTREE_STATIC_DELTA_OPEN_FLAGS_SKIP_CHECKSUM) > 0;
+ 
+-  /* Use the declared usize from the delta header as the decompression limit
+-   * when available, capped to the hard maximum.  If the caller passes 0
+-   * (e.g. the show/dump path) fall back to the hard cap alone.
+-   *
+-   * The declared usize only covers the final on-disk size of the objects
+-   * a part produces, not the part payload itself (which additionally
+-   * contains the mode/xattr tables and operations bytecode).  Add a
+-   * margin on top of usize, derived from the number of objects in the
+-   * part, so legitimate parts aren't rejected; see
+-   * _ostree_static_delta_compute_part_margin().
++  /* Decompression-bomb defense: the flat hard cap.  A tighter,
++   * exact-size-derived limit may be layered on top of this by callers
++   * that have that information; see OSTREE_STATIC_DELTA_PART_MAX_USIZE_BYTES.
+    */
+   guint64 max_part_usize = OSTREE_STATIC_DELTA_PART_MAX_USIZE_BYTES;
+-  if (expected_usize > 0)
+-    {
+-      const guint64 margin
+-          = _ostree_static_delta_compute_part_margin (expected_usize, expected_n_objects);
+-      guint64 bounded_usize;
+-      if (!g_uint64_checked_add (&bounded_usize, expected_usize, margin))
+-        bounded_usize = G_MAXUINT64;
+-      if (bounded_usize < max_part_usize)
+-        max_part_usize = bounded_usize;
+-    }
+ 
+   /* We either take a fd or a GBytes reference */
+   g_return_val_if_fail (G_IS_FILE_DESCRIPTOR_BASED (part_in) || inline_part_bytes != NULL, FALSE);
+@@ -820,7 +771,7 @@ show_one_part (OstreeRepo *self, gboolean swap_endian, const char *from, const c
+ 
+   g_autoptr (GVariant) part = NULL;
+   if (!_ostree_static_delta_part_open (part_in, NULL, OSTREE_STATIC_DELTA_OPEN_FLAGS_SKIP_CHECKSUM,
+-                                       NULL, 0, 0, &part, cancellable, error))
++                                       NULL, &part, cancellable, error))
+     return FALSE;
+ 
+   {
+diff --git a/src/libostree/ostree-repo-static-delta-private.h b/src/libostree/ostree-repo-static-delta-private.h
+index 7d325448ed..2fd5135a7c 100644
+--- a/src/libostree/ostree-repo-static-delta-private.h
++++ b/src/libostree/ostree-repo-static-delta-private.h
+@@ -32,73 +32,21 @@ G_BEGIN_DECLS
+  * provides ~16x headroom over the default, which is generous enough to
+  * accommodate large custom --max-chunk-size values while still rejecting
+  * decompression bombs that would expand to gigabytes.
++ *
++ * This is also the sole bound applied to deltas that don't carry the
++ * exact-payload-size metadata (see
++ * OSTREE_STATIC_DELTA_PART_PAYLOAD_SIZES_KEY below): the declared "usize"
++ * in a delta part header only accounts for the final on-disk size of the
++ * objects the part will produce, not the mode/xattr tables, opcode
++ * bytecode, or raw payload data (including, for bsdiff'd objects, the
++ * entire patch stream) that also make up the part's decompressed
++ * payload.  There is no way to derive a tight, correct bound from usize
++ * alone -- a part with a single large bsdiff'd object can have a
++ * decompressed payload many times its usize -- so deltas lacking the
++ * exact size just fall back to this flat cap.
+  */
+ #define OSTREE_STATIC_DELTA_PART_MAX_USIZE_BYTES (512ULL * 1024ULL * 1024ULL)
+ 
+-/* The declared "usize" in a delta part header only accounts for the final
+- * on-disk size of the objects the part will produce; the part payload
+- * that actually gets decompressed is larger.  The constants below bound
+- * that difference so a decompression limit can be derived from usize
+- * without either false-positiving on legitimate parts or degenerating
+- * into a check that never rejects anything (see
+- * _ostree_static_delta_compute_part_margin() in
+- * ostree-repo-static-delta-core.c for how they're combined).  Each term
+- * is sized from the actual on-disk formats in
+- * ostree-repo-static-delta-compilation.c and ostree-varint.c rather than
+- * from a single round guess, so the resulting margin stays proportionate
+- * as the number of objects in a part grows.
+- */
+-
+-/* Flat per-part overhead: GVariant framing for the part's outer tuple and
+- * the operations/payload byte arrays.  A few KiB is generous here; this
+- * doesn't scale with content.
+- */
+-#define OSTREE_STATIC_DELTA_PART_FIXED_OVERHEAD_BYTES (4ULL * 1024ULL)
+-
+-/* Per-object operations overhead: each object contributes a mode table
+- * entry ("(uuu)", 12 bytes, deduplicated but bounded per-object in the
+- * worst case) plus opcode bytecode.  _ostree_write_varuint64() emits at
+- * most 10 bytes, and the largest per-object opcode sequence is the
+- * bsdiff path (SET_READ_SOURCE, OPEN, BSPATCH, CLOSE, UNSET_READ_SOURCE:
+- * 5 opcodes + 6 varints = 65 bytes) plus its embedded 32-byte source
+- * checksum, which isn't counted in usize at all.  109 bytes worst case;
+- * round up generously.
+- */
+-#define OSTREE_STATIC_DELTA_PART_OP_OVERHEAD_PER_OBJECT_BYTES 256ULL
+-
+-/* Per-object xattr allowance: xattrs are written into the payload in full
+- * and aren't reflected in usize either.  There's no way to derive a true
+- * worst-case bound for this from filesystem limits: ext4 caps total
+- * attribute bytes per inode at ~4 KiB (one external block plus a little
+- * in-inode space), but that bound doesn't hold in general -- XFS and
+- * Btrfs impose no total per-inode limit, and even ext4 with the
+- * (non-default) ea_inode feature can push individual values up to
+- * XATTR_SIZE_MAX (64 KiB) each across its ~100-250 max entries.  A file
+- * could in principle carry many such values on some filesystem; fully
+- * covering that here would require a per-object allowance in the tens of
+- * MiB, which for parts with more than a handful of objects would swamp
+- * this margin and degenerate the check back into "always equal to the
+- * hard cap" -- the exact failure mode we moved away from a flat
+- * 1 MiB/object margin to avoid.  So use a single XATTR_SIZE_MAX (64 KiB)
+- * as a generous but pragmatic allowance: real xattr sets (SELinux label,
+- * capabilities, ACLs, IMA/EVM signatures) total well under 2 KiB in
+- * practice, so this covers legitimate content with 30x+ headroom to
+- * spare.  Pathological xattr counts beyond that are left to
+- * OSTREE_STATIC_DELTA_PART_MAX_USIZE_BYTES, the same hard-cap backstop
+- * that bounds this whole margin.
+- */
+-#define OSTREE_STATIC_DELTA_PART_XATTR_ALLOWANCE_PER_OBJECT_BYTES (64ULL * 1024ULL)
+-
+-/* Rollsum overhead divisor: rollsum (bsdiff-like binary delta against a
+- * similar file) emits a WRITE op per matched/unmatched chunk, and chunk
+- * boundaries come from bupsplit's content-defined chunking, which
+- * averages BUP_BLOBSIZE (8 KiB) per chunk.  At up to ~64 bytes of opcode
+- * overhead per chunk, that's an expected overhead of roughly usize/128;
+- * dividing by 32 instead bakes in a further 4x safety margin for content
+- * that chunks more finely than average.
+- */
+-#define OSTREE_STATIC_DELTA_PART_ROLLSUM_OVERHEAD_DIVISOR 32ULL
+-
+ /* 1 byte for object type, 32 bytes for checksum */
+ #define OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN 33
+ 
+@@ -217,8 +165,7 @@ typedef enum
+ 
+ gboolean _ostree_static_delta_part_open (GInputStream *part_in, GBytes *inline_part_bytes,
+                                          OstreeStaticDeltaOpenFlags flags,
+-                                         const char *expected_checksum, guint64 expected_usize,
+-                                         guint32 expected_n_objects, GVariant **out_part,
++                                         const char *expected_checksum, GVariant **out_part,
+                                          GCancellable *cancellable, GError **error);
+ 
+ typedef struct
+
+From 12f3af8c02b9e44890dcc392baf0ba9b3998ed6c Mon Sep 17 00:00:00 2001
+From: Colin Walters <walters@verbum.org>
+Date: Tue, 18 Aug 2026 09:14:09 -0400
+Subject: [PATCH 2/2] static-delta: Drop flat per-part decompression-size cap
+
+The 512 MiB flat cap on decompressed part size is heuristic.
+Since we broke flatpak firefox deltas with incorrect heuristics,
+back that out until we come up with a design that is precise and
+tighter.
+
+This deliberately reopens <https://github.com/ostreedev/ostree/security/advisories/GHSA-7cgc-gp99-6jmm> for now.
+
+Assisted-by: https://github.com/cgwalters/cgwalters#llms
+Signed-off-by: Colin Walters <walters@verbum.org>
+---
+ .../ostree-repo-static-delta-compilation.c    | 17 +------------
+ src/libostree/ostree-repo-static-delta-core.c | 18 +-------------
+ .../ostree-repo-static-delta-private.h        | 24 -------------------
+ src/ostree/ot-builtin-static-delta.c          |  2 +-
+ 4 files changed, 3 insertions(+), 58 deletions(-)
+
+diff --git a/src/libostree/ostree-repo-static-delta-compilation.c b/src/libostree/ostree-repo-static-delta-compilation.c
+index 7b986a17e7..c3515cd1a2 100644
+--- a/src/libostree/ostree-repo-static-delta-compilation.c
++++ b/src/libostree/ostree-repo-static-delta-compilation.c
+@@ -259,21 +259,6 @@ finish_part (OstreeStaticDeltaBuilder *builder, GError **error)
+     g_variant_ref_sink (delta_part_content);
+   }
+ 
+-  /* Reject parts whose uncompressed payload exceeds the hard limit that
+-   * consumers enforce (OSTREE_STATIC_DELTA_PART_MAX_USIZE_BYTES).  Without
+-   * this check, a large --max-chunk-size would produce deltas that every
+-   * client rejects at apply time (CVE / RHEL-189208).
+-   */
+-  {
+-    gsize payload_size = g_variant_get_size (delta_part_content);
+-    if (payload_size > OSTREE_STATIC_DELTA_PART_MAX_USIZE_BYTES)
+-      return glnx_throw (error,
+-                         "Delta part %u uncompressed payload size %" G_GSIZE_FORMAT
+-                         " bytes exceeds maximum %" G_GUINT64_FORMAT "; reduce --max-chunk-size",
+-                         builder->parts->len, payload_size,
+-                         (guint64)OSTREE_STATIC_DELTA_PART_MAX_USIZE_BYTES);
+-  }
+-
+   /* Hardcode xz for now */
+   compressor = (GConverter *)_ostree_lzma_compressor_new (NULL);
+   compression_type_char = 'x';
+@@ -1277,7 +1262,7 @@ get_fallback_headers (OstreeRepo *self, OstreeStaticDeltaBuilder *builder, GVari
+  * are known:
+  *   - min-fallback-size: u: Minimum uncompressed size in megabytes to use fallback, 0 to disable
+  * fallbacks
+- *   - max-chunk-size: u: Maximum size in megabytes of a delta part (hard cap: 512 MiB)
++ *   - max-chunk-size: u: Maximum size in megabytes of a delta part
+  *   - max-bsdiff-size: u: Maximum size in megabytes to consider bsdiff compression
+  *   for input files
+  *   - compression: y: Compression type: 0=none, x=lzma, g=gzip
+diff --git a/src/libostree/ostree-repo-static-delta-core.c b/src/libostree/ostree-repo-static-delta-core.c
+index abcca819a3..20adb253ec 100644
+--- a/src/libostree/ostree-repo-static-delta-core.c
++++ b/src/libostree/ostree-repo-static-delta-core.c
+@@ -641,12 +641,6 @@ _ostree_static_delta_part_open (GInputStream *part_in, GBytes *inline_part_bytes
+   const gboolean trusted = (flags & OSTREE_STATIC_DELTA_OPEN_FLAGS_VARIANT_TRUSTED) > 0;
+   const gboolean skip_checksum = (flags & OSTREE_STATIC_DELTA_OPEN_FLAGS_SKIP_CHECKSUM) > 0;
+ 
+-  /* Decompression-bomb defense: the flat hard cap.  A tighter,
+-   * exact-size-derived limit may be layered on top of this by callers
+-   * that have that information; see OSTREE_STATIC_DELTA_PART_MAX_USIZE_BYTES.
+-   */
+-  guint64 max_part_usize = OSTREE_STATIC_DELTA_PART_MAX_USIZE_BYTES;
+-
+   /* We either take a fd or a GBytes reference */
+   g_return_val_if_fail (G_IS_FILE_DESCRIPTOR_BASED (part_in) || inline_part_bytes != NULL, FALSE);
+   g_return_val_if_fail (skip_checksum || expected_checksum != NULL, FALSE);
+@@ -698,15 +692,6 @@ _ostree_static_delta_part_open (GInputStream *part_in, GBytes *inline_part_bytes
+           g_variant_ref_sink (ret_part);
+         }
+ 
+-      /* Enforce the size limit so that an attacker cannot bypass the
+-       * decompression-bomb defence by setting compression type to 0.
+-       */
+-      if (g_variant_get_size (ret_part) > max_part_usize)
+-        return glnx_throw (error,
+-                           "Uncompressed delta part size %" G_GSIZE_FORMAT
+-                           " exceeds maximum %" G_GUINT64_FORMAT,
+-                           g_variant_get_size (ret_part), max_part_usize);
+-
+       if (!skip_checksum)
+         g_checksum_update (checksum, g_variant_get_data (ret_part), g_variant_get_size (ret_part));
+ 
+@@ -715,8 +700,7 @@ _ostree_static_delta_part_open (GInputStream *part_in, GBytes *inline_part_bytes
+       {
+         g_autoptr (GConverter) decomp = (GConverter *)_ostree_lzma_decompressor_new ();
+         g_autoptr (GInputStream) convin = g_converter_input_stream_new (source_in, decomp);
+-        g_autoptr (GBytes) buf = ot_map_anonymous_tmpfile_from_content_with_limit (
+-            convin, max_part_usize, cancellable, error);
++        g_autoptr (GBytes) buf = ot_map_anonymous_tmpfile_from_content (convin, cancellable, error);
+         if (!buf)
+           return FALSE;
+ 
+diff --git a/src/libostree/ostree-repo-static-delta-private.h b/src/libostree/ostree-repo-static-delta-private.h
+index 2fd5135a7c..a6f36162d4 100644
+--- a/src/libostree/ostree-repo-static-delta-private.h
++++ b/src/libostree/ostree-repo-static-delta-private.h
+@@ -23,30 +23,6 @@
+ 
+ G_BEGIN_DECLS
+ 
+-/* Maximum uncompressed size for a single static delta part (512 MiB).
+- * Enforced on both generation and consumption sides to prevent
+- * decompression bombs from exhausting memory/disk (CVE / RHEL-189208).
+- *
+- * The delta compiler splits parts at max-chunk-size (default 32 MB), so
+- * legitimate parts are typically well under 32 MB uncompressed.  512 MiB
+- * provides ~16x headroom over the default, which is generous enough to
+- * accommodate large custom --max-chunk-size values while still rejecting
+- * decompression bombs that would expand to gigabytes.
+- *
+- * This is also the sole bound applied to deltas that don't carry the
+- * exact-payload-size metadata (see
+- * OSTREE_STATIC_DELTA_PART_PAYLOAD_SIZES_KEY below): the declared "usize"
+- * in a delta part header only accounts for the final on-disk size of the
+- * objects the part will produce, not the mode/xattr tables, opcode
+- * bytecode, or raw payload data (including, for bsdiff'd objects, the
+- * entire patch stream) that also make up the part's decompressed
+- * payload.  There is no way to derive a tight, correct bound from usize
+- * alone -- a part with a single large bsdiff'd object can have a
+- * decompressed payload many times its usize -- so deltas lacking the
+- * exact size just fall back to this flat cap.
+- */
+-#define OSTREE_STATIC_DELTA_PART_MAX_USIZE_BYTES (512ULL * 1024ULL * 1024ULL)
+-
+ /* 1 byte for object type, 32 bytes for checksum */
+ #define OSTREE_STATIC_DELTA_OBJTYPE_CSUM_LEN 33
+ 
+diff --git a/src/ostree/ot-builtin-static-delta.c b/src/ostree/ot-builtin-static-delta.c
+index 66d5faa6f8..ba91175e45 100644
+--- a/src/ostree/ot-builtin-static-delta.c
++++ b/src/ostree/ot-builtin-static-delta.c
+@@ -96,7 +96,7 @@ static GOptionEntry generate_options[] = {
+   { "max-bsdiff-size", 0, 0, G_OPTION_ARG_STRING, &opt_max_bsdiff_size,
+     "Maximum size in megabytes to consider bsdiff compression for input files", NULL },
+   { "max-chunk-size", 0, 0, G_OPTION_ARG_STRING, &opt_max_chunk_size,
+-    "Maximum size of delta chunks in megabytes (hard cap: 512 MiB)", NULL },
++    "Maximum size of delta chunks in megabytes", NULL },
+   { "filename", 0, 0, G_OPTION_ARG_FILENAME, &opt_filename,
+     "Write the delta content to PATH (a directory).  If not specified, the OSTree repository is "
+     "used",

--- a/staging/ostree/ostree.spec
+++ b/staging/ostree/ostree.spec
@@ -1,0 +1,190 @@
+# We haven't tried to ship the tests on RHEL
+%if 0%{?rhel}
+    %bcond_with tests
+%else
+    %bcond_without tests
+%endif
+
+Summary: Tool for managing bootable, immutable filesystem trees
+Name: ostree
+Version: 2026.3
+Release: 2
+Source0: https://github.com/ostreedev/%{name}/releases/download/v%{version}/libostree-%{version}.tar.xz
+License: LGPL-2.0-or-later
+URL: https://ostreedev.github.io/ostree/
+
+# upstream patches
+# https://github.com/ostreedev/ostree/pull/3645
+Patch0: 3645.patch
+
+# Conditional to ELN right now to reduce blast radius; xref
+# https://github.com/containers/composefs/pull/229#issuecomment-1838735764
+%if 0%{?rhel} >= 10
+ExcludeArch:    %{ix86}
+%endif
+
+BuildRequires: make
+BuildRequires: git
+# We always run autogen.sh
+BuildRequires: autoconf automake libtool
+# For docs
+BuildRequires: gtk-doc
+# Core requirements
+BuildRequires: pkgconfig(zlib)
+BuildRequires: pkgconfig(libcurl)
+BuildRequires: openssl-devel
+BuildRequires: pkgconfig(composefs)
+%if %{with tests}
+BuildRequires: pkgconfig(libsoup-3.0)
+%endif
+BuildRequires: libattr-devel
+# The tests require attr
+BuildRequires: attr
+# Extras
+BuildRequires: pkgconfig(libarchive)
+BuildRequires: pkgconfig(liblzma)
+BuildRequires: pkgconfig(libselinux)
+BuildRequires: pkgconfig(mount)
+%if 0%{?fedora} <= 36
+BuildRequires: pkgconfig(fuse)
+%else
+BuildRequires: pkgconfig(fuse3)
+%endif
+BuildRequires: pkgconfig(e2p)
+BuildRequires: libcap-devel
+BuildRequires: gpgme-devel
+BuildRequires: pkgconfig(libsystemd)
+BuildRequires: /usr/bin/g-ir-scanner
+BuildRequires: dracut
+BuildRequires:  bison
+
+# Runtime requirements
+Requires: dracut
+Requires: /usr/bin/gpgv2
+Requires: systemd-units
+Requires: %{name}-libs%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+# Strictly speaking, this is not a current hard requirement, but it will
+# be in the future.
+Requires: composefs
+
+%description
+libostree is a shared library designed primarily for
+use by higher level tools to manage host systems (e.g. rpm-ostree),
+as well as container tools like flatpak and the atomic CLI.
+
+%package libs
+Summary: C shared libraries %{name}
+Requires: bubblewrap
+
+%description libs
+The %{name}-libs provides shared libraries for %{name}.
+
+%package devel
+Summary: Development headers for %{name}
+Requires: %{name}-libs%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+
+%description devel
+The %{name}-devel package includes the header files for the %{name} library.
+
+%ifnarch s390 s390x
+%package grub2
+Summary: GRUB2 integration for OSTree
+%ifnarch aarch64 %{arm}
+Requires: grub2
+%else
+Requires: grub2-efi
+%endif
+Requires: ostree
+
+%description grub2
+GRUB2 integration for OSTree
+%endif
+
+%if %{with tests}
+%package tests
+Summary: Tests for the %{name} package
+Requires: %{name}%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+Requires: %{name}-libs%{?_isa} = %{?epoch:%{epoch}:}%{version}-%{release}
+
+%description tests
+This package contains tests that can be used to verify
+the functionality of the installed %{name} package.
+%endif
+
+%prep
+%autosetup -Sgit -n libostree-%{version}
+
+%build
+env NOCONFIGURE=1 ./autogen.sh
+%configure --disable-silent-rules \
+           --enable-gtk-doc \
+           --with-selinux \
+           --with-curl \
+           --with-openssl \
+           --without-soup \
+           --with-composefs \
+           %{?with_tests:--with-soup3} \
+           %{?!with_tests:--without-soup3} \
+           %{?with_tests:--enable-installed-tests=exclusive} \
+           --with-dracut=yesbutnoconf
+%make_build
+
+%install
+%make_install INSTALL="install -p -c"
+find %{buildroot} -name '*.la' -delete
+
+# Needed to enable the service at compose time currently
+%post
+%systemd_post ostree-remount.service
+
+%preun
+%systemd_preun ostree-remount.service
+
+%files
+%{!?_licensedir:%global license %%doc}
+%license COPYING
+%doc README.md
+%{_bindir}/ostree
+%{_bindir}/rofiles-fuse
+%{_datadir}/ostree
+%{_datadir}/bash-completion/completions/*
+%dir %{_prefix}/lib/dracut/modules.d/50ostree
+%{_prefix}/lib/systemd/system/ostree*.*
+%{_prefix}/lib/dracut/modules.d/50ostree/*
+%{_mandir}/man*/*.gz
+%{_prefix}/lib/systemd/system-generators/ostree-system-generator
+%exclude %{_sysconfdir}/grub.d/*ostree
+%exclude %{_libexecdir}/libostree/grub2*
+%{_prefix}/lib/tmpfiles.d/*
+%{_prefix}/lib/ostree
+# Moved in git master
+%{_libexecdir}/libostree/*
+
+%files libs
+%{_sysconfdir}/ostree
+%{_libdir}/*.so.1*
+%{_libdir}/girepository-1.0/OSTree-1.0.typelib
+
+%files devel
+%{_libdir}/lib*.so
+%{_includedir}/*
+%{_libdir}/pkgconfig/*
+%dir %{_datadir}/gtk-doc/html/ostree
+%{_datadir}/gtk-doc/html/ostree
+%{_datadir}/gir-1.0/OSTree-1.0.gir
+
+%ifnarch s390 s390x
+%files grub2
+%{_sysconfdir}/grub.d/*ostree
+%dir %{_libexecdir}/libostree
+%{_libexecdir}/libostree/grub2*
+%endif
+
+%if %{with tests}
+%files tests
+%{_libexecdir}/installed-tests
+%{_datadir}/installed-tests
+%endif
+
+%changelog
+%autochangelog


### PR DESCRIPTION
See: https://github.com/ostreedev/ostree/issues/3635

I tested this with a usr-overlay and that made flatpaks upgrade again
for me.

We should test at least one system upgrade with bootc/rpm-ostree with
this change included just to be sure it didn't break anything on that
side.


This was based on https://src.fedoraproject.org/rpms/ostree/tree/f7aa961f8bdfcc4cedebb43b92d120827d1f4a2d and I included the line for the patch and changed the release field