### PR TITLE
ci: migrate Podman workflows to Ubuntu 26.04

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -79,7 +79,7 @@ jobs:
           echo "specs=$(jq -r -c '.specs' <<< "${MATRIX}")" >> $GITHUB_OUTPUT
 
   build_packages:
-    runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-26.04' || 'ubuntu-26.04-arm' }}
     needs: changed_files
     name: Build RPM package
     if: needs.changed_files.outputs.any_changed == 'true'
@@ -94,12 +94,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Install dependencies
-        if: matrix.platform == 'arm64'
+      - name: Show container tooling versions
         run: |
-          sudo apt update -y
-          sudo apt install -y \
-            podman
+          podman --version
+          buildah --version
+          podman info
 
       - name: Setup Just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - 'ublue-builder/*'
+      - '.github/workflows/builder.yml'
   push:
     branches:
       - main
@@ -42,7 +43,7 @@ jobs:
 
   build_push:
     name: Build and push image
-    runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-26.04' || 'ubuntu-26.04-arm' }}
     timeout-minutes: 30
     needs: generate_matrix
     permissions:
@@ -56,12 +57,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - name: Install dependencies
-        if: matrix.platform == 'arm64'
+      - name: Show container tooling versions
         run: |
-          sudo apt update -y
-          sudo apt install -y \
-            podman
+          podman --version
+          buildah --version
+          podman info
 
       - name: Build Image
         id: build_image


### PR DESCRIPTION
## Summary

- move Podman/Buildah image and RPM package build jobs to Ubuntu 26.04 runners
- remove the ARM-only Podman installation workaround
- log Podman and Buildah versions before container work, and validate builder workflow changes in pull requests

Ubuntu 24.04 current Podman upgrade has produced filesystem-corruption reports in the Universal Blue ecosystem:

- https://github.com/ublue-os/bazzite/issues/5604
- https://github.com/ublue-os/ucore/issues/431

It has also produced a libpod_lock failure in packages CI:

- https://github.com/ublue-os/packages/actions/runs/32831848037/job/98055143807#step:5:72

Ubuntu 26.04 provides a compatible Podman/Buildah stack on both amd64 and ARM runners.

This PR is expected to address those issues.